### PR TITLE
Replaced environment variables with the ini parameters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,22 +9,7 @@ install:
   - sudo apt-get update
   - sudo apt-get install lcov
 script:
-  - export PHP_HOME=$( cd "$(dirname $(which php))" && cd .. && pwd )
-  - export LIB_SNOWFLAKE_CLIENT_DIR=$(cd ./libsnowflakeclient && pwd)
-  - export SNOWFLAKE_TEST_CA_BUNDLE_FILE=$LIB_SNOWFLAKE_CLIENT_DIR/cacert.pem
-  - eval $(jq -r '.testconnection | to_entries | map("export \(.key)=\(.value|tostring)")|.[]' parameters.json)
-  - echo $PHP_HOME
-  - echo $(which phpize)
-  - echo $(which php-config)
-  - echo $SNOWFLAKE_TEST_CA_BUNDLE_FILE
-  - echo $SNOWFLAKE_TEST_ACCOUNT
-  - echo $SNOWFLAKE_TEST_USER
-  - echo $SNOWFLAKE_TEST_DATABASE
-  - echo $SNOWFLAKE_TEST_SCHEMA
-  - echo $SNOWFLAKE_TEST_WAREHOUSE
-  - REPORT_COVERAGE=1 ./scripts/build_pdo_snowflake.sh
-  - REPORT_EXIT_STATUS=1 NO_INTERACTION=true make test
-  - gcov -o .libs snowflake_driver.c snowflake_stmt.c
+  - ./scripts/run_travis.sh
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 env:

--- a/scripts/run_travis.sh
+++ b/scripts/run_travis.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -e
+#
+# Run Travis Build and Tests
+#
+set -o pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+cd $DIR/..
+export PHP_HOME=$( cd "$(dirname $(which php))" && cd .. && pwd )
+export LIB_SNOWFLAKE_CLIENT_DIR=$(cd ./libsnowflakeclient && pwd)
+export SNOWFLAKE_TEST_CA_BUNDLE_FILE=$LIB_SNOWFLAKE_CLIENT_DIR/cacert.pem
+eval $(jq -r '.testconnection | to_entries | map("export \(.key)=\(.value|tostring)")|.[]' ./parameters.json)
+echo "PHP_HOME:   $PHP_HOME"
+echo "phpize:     $(which phpize)"
+echo "php-config: $(which php-config)"
+REPORT_COVERAGE=1 $DIR/build_pdo_snowflake.sh
+export REPORT_EXIT_STATUS=1
+export NO_INTERACTION=true
+echo "===> Test parameters"
+env | grep SNOWFLAKE_TEST > $DIR/../testenv.ini
+cat $DIR/../testenv.ini | grep -v PASSWORD
+echo "===> Running Tests"
+if ! make test; then
+    echo "Test Failed"
+    ls -l tests
+    for f in $(ls tests/*); do echo "===> $f"; cat $f; echo; done
+    exit 1
+else
+    gcov -o .libs snowflake_driver.c snowflake_stmt.c
+fi

--- a/tests/connect.phpt
+++ b/tests/connect.phpt
@@ -2,18 +2,32 @@
 PDO_SNOWFLAKE:
 --FILE--
 <?php
-    $host = getenv('SNOWFLAKE_TEST_HOST');
-    $port = getenv('SNOWFLAKE_TEST_PORT');
-    $account = getenv('SNOWFLAKE_TEST_ACCOUNT');
-    $user = getenv('SNOWFLAKE_TEST_USER');
-    $password = getenv('SNOWFLAKE_TEST_PASSWORD');
-    $database = getenv('SNOWFLAKE_TEST_DATABASE');
-    $schema = getenv('SNOWFLAKE_TEST_SCHEMA');
-    $warehouse = getenv('SNOWFLAKE_TEST_WAREHOUSE');
-    $role = getenv('SNOWFLAKE_TEST_ROLE');
-    $protocol = getenv('SNOWFLAKE_TEST_PROTOCOL');
-    $insecure_mode = (bool) getenv('SNOWFLAKE_TEST_INSECURE_MODE');
+    $p = parse_ini_file(getenv('PWD') . "/testenv.ini");
+
+    $account = $p['SNOWFLAKE_TEST_ACCOUNT'];
+    $user = $p['SNOWFLAKE_TEST_USER'];
+    $password = $p['SNOWFLAKE_TEST_PASSWORD'];
+    $database = $p['SNOWFLAKE_TEST_DATABASE'];
+    $schema = $p['SNOWFLAKE_TEST_SCHEMA'];
+    $warehouse = $p['SNOWFLAKE_TEST_WAREHOUSE'];
+    $role = $p['SNOWFLAKE_TEST_ROLE'];
+
+    if (array_key_exists('SNOWFLAKE_TEST_HOST', $p)) {
+        $host = getenv('SNOWFLAKE_TEST_HOST');
+    } else {
+        $host = $account . ".snowflakecomputing.com";
+    }
+    $port = "443";
+    if (array_key_exists('SNOWFLAKE_TEST_PORT', $p)) {
+        $port = getenv('SNOWFLAKE_TEST_PORT');
+    }
+    $protocol="https";
+    if (array_key_exists('SNOWFLAKE_TEST_PROTOCOL', $p)) {
+        $protocol = $p['SNOWFLAKE_TEST_PROTOCOL'];
+    }
+
     $dsn = "snowflake:host=$host;port=$port;account=$account;database=$database;schema=$schema;warehouse=$warehouse;role=$role;protocol=$protocol";
+
     $ca_bundle_file = getenv('SNOWFLAKE_TEST_CA_BUNDLE_FILE');
     $options = array(PDO::SNOWFLAKE_ATTR_SSL_CAPATH => $ca_bundle_file);
     try {
@@ -21,10 +35,9 @@ PDO_SNOWFLAKE:
         echo 'Connected to Snowflake';
     } catch (PDOException $e) {
         echo 'Connection failed: ' . $e->getMessage();
-        echo "dsn is: $dsn";
+        echo "dsn is: $dsn\n";
+        echo "user is: $user\n";
     }
-
-    $dbh = null;
 ?>
 --EXPECT--
 Connected to Snowflake


### PR DESCRIPTION
For some reason, the environment variables are not set in the process of PHP test when running `make test`, so no connect information is propagated.

I tried to fix it by multiple ways, but none worked.

Now this change set is to replace the environment variable test connection parameters with ini file.
