### PR TITLE
ignore test env ini. generate test env ini file in build and not at runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ cmake-build-debug/
 cmake-build/
 .idea/
 logs/
+testenv.ini

--- a/scripts/run_travis.sh
+++ b/scripts/run_travis.sh
@@ -14,11 +14,10 @@ eval $(jq -r '.testconnection | to_entries | map("export \(.key)=\(.value|tostri
 echo "PHP_HOME:   $PHP_HOME"
 echo "phpize:     $(which phpize)"
 echo "php-config: $(which php-config)"
-REPORT_COVERAGE=1 $DIR/build_pdo_snowflake.sh
+REPORT_COVERAGE=1 $DIR/build_pdo_snowflake.sh -r
 export REPORT_EXIT_STATUS=1
 export NO_INTERACTION=true
 echo "===> Test parameters"
-env | grep SNOWFLAKE_TEST > $DIR/../testenv.ini
 cat $DIR/../testenv.ini | grep -v PASSWORD
 echo "===> Running Tests"
 if ! make test; then


### PR DESCRIPTION
Forgot to ignore the test env file which includes the credential.