### PR TITLE
reformat PDO codes. Use data length instead of strlen

### DIFF
--- a/libsnowflakeclient/lib/snowflake_client.c
+++ b/libsnowflakeclient/lib/snowflake_client.c
@@ -562,11 +562,8 @@ SNOWFLAKE_STATUS STDCALL snowflake_fetch(SNOWFLAKE_STMT *sfstmt) {
             } else if (result->type == SF_C_TYPE_FLOAT64) {
                 *(float64 *) result->value = (float64) strtod(raw_result->valuestring, NULL);
             } else if (result->type == SF_C_TYPE_STRING) {
+                /* copy original data as is except Date/Time/Timestamp/Binary type */
                 strncpy(result->value, raw_result->valuestring, result->max_length);
-                // If string is not null terminated, then add the terminator yourself
-                if (((char *) result->value)[result->max_length - 1] != '\0') {
-                    ((char *) result->value)[result->max_length - 1] = '\0';
-                }
             } else if (result->type == SF_C_TYPE_TIMESTAMP) {
                 // TODO Do some timestamp stuff here
             } else {

--- a/pdo_snowflake.c
+++ b/pdo_snowflake.c
@@ -1,11 +1,12 @@
 /* Copyright (c) 2017 Snowflake Computing Inc. All right reserved.  */
 
 #ifdef HAVE_CONFIG_H
+
 #include "config.h"
+
 #endif
 
 #include "php.h"
-#include "php_ini.h"
 #include "ext/standard/info.h"
 #include "pdo/php_pdo.h"
 #include "pdo/php_pdo_driver.h"
@@ -15,11 +16,12 @@
 ZEND_DECLARE_MODULE_GLOBALS(pdo_snowflake)
 
 #ifdef COMPILE_DL_PDO_SNOWFLAKE
-#   if (PHP_VERSION_ID>=70000)
+#   if (PHP_VERSION_ID >= 70000)
 #       ifdef ZTS
 ZEND_TSRMLS_CACHE_DEFINE()
 #       endif /* ZTS */
 #   endif /* PHP_VERSION_ID */
+
 ZEND_GET_MODULE(pdo_snowflake)
 #endif /* COMPILE_DL_PDO_SNOWFLAKE */
 
@@ -27,20 +29,23 @@ ZEND_GET_MODULE(pdo_snowflake)
 */
 PHP_INI_BEGIN()
 #if PDO_DBG_ENABLED
-		STD_PHP_INI_ENTRY("pdo_snowflake.debug",	NULL, PHP_INI_SYSTEM, OnUpdateString, debug, zend_pdo_snowflake_globals, pdo_snowflake_globals)
+    STD_PHP_INI_ENTRY
+    ("pdo_snowflake.debug", NULL, PHP_INI_SYSTEM, OnUpdateString, debug,
+     zend_pdo_snowflake_globals, pdo_snowflake_globals)
 #endif
 PHP_INI_END()
 /* }}} */
 
 /* TODO: adhoc logger until Snowflake client provides it. */
-void pdo_snowflake_log(int line, const char* filename, const char* severity, char *fmt, ...)
+void pdo_snowflake_log(int line, const char *filename, const char *severity,
+                       char *fmt, ...)
 {
   va_list args;
   va_start (args, fmt);
 
-  FILE* fp = fopen("/tmp/php.log", "a");
+  FILE *fp = fopen("/tmp/php.log", "a");
   fprintf(fp, "[%-6s] %-70s:%5d - ", severity, filename, line);
-  vfprintf (fp, fmt, args);
+  vfprintf(fp, fmt, args);
   fprintf(fp, "\n");
   fclose(fp);
 
@@ -51,12 +56,15 @@ void pdo_snowflake_log(int line, const char* filename, const char* severity, cha
  */
 static PHP_MINIT_FUNCTION(pdo_snowflake)
 {
-	REGISTER_INI_ENTRIES();
+  REGISTER_INI_ENTRIES();
 
-	REGISTER_PDO_CLASS_CONST_LONG("SNOWFLAKE_ATTR_SSL_CAPATH", (zend_long)PDO_SNOWFLAKE_ATTR_SSL_CAPATH);
-	REGISTER_PDO_CLASS_CONST_LONG("SNOWFLAKE_ATTR_SSL_VERIFY_CERTIFICATE_REVOCATION_STATUS", (zend_long)PDO_SNOWFLAKE_ATTR_SSL_VERIFY_CERTIFICATE_REVOCATION_STATUS);
+  REGISTER_PDO_CLASS_CONST_LONG("SNOWFLAKE_ATTR_SSL_CAPATH",
+                                (zend_long) PDO_SNOWFLAKE_ATTR_SSL_CAPATH);
+  REGISTER_PDO_CLASS_CONST_LONG(
+    "SNOWFLAKE_ATTR_SSL_VERIFY_CERTIFICATE_REVOCATION_STATUS",
+    (zend_long) PDO_SNOWFLAKE_ATTR_SSL_VERIFY_CERTIFICATE_REVOCATION_STATUS);
 
-	return php_pdo_register_driver(&pdo_snowflake_driver);
+  return php_pdo_register_driver(&pdo_snowflake_driver);
 }
 /* }}} */
 
@@ -64,10 +72,10 @@ static PHP_MINIT_FUNCTION(pdo_snowflake)
  */
 static PHP_MSHUTDOWN_FUNCTION(pdo_snowflake)
 {
-	php_pdo_unregister_driver(&pdo_snowflake_driver);
-	UNREGISTER_INI_ENTRIES();
+  php_pdo_unregister_driver(&pdo_snowflake_driver);
+  UNREGISTER_INI_ENTRIES();
 
-	return SUCCESS;
+  return SUCCESS;
 }
 /* }}} */
 
@@ -75,16 +83,16 @@ static PHP_MSHUTDOWN_FUNCTION(pdo_snowflake)
  */
 static PHP_MINFO_FUNCTION(pdo_snowflake)
 {
-	php_info_print_table_start();
+  php_info_print_table_start();
 
-	php_info_print_table_header(2, "PDO Driver for Snowflake", "enabled");
-    /* TODO: get Snowflake Driver version, etc*/
-	php_info_print_table_row(2, "Client API version", "0.1");
+  php_info_print_table_header(2, "PDO Driver for Snowflake", "enabled");
+  /* TODO: get Snowflake Driver version, etc*/
+  php_info_print_table_row(2, "Client API version", "0.1");
 
-	php_info_print_table_end();
+  php_info_print_table_end();
 
 #ifndef PHP_WIN32
-	DISPLAY_INI_ENTRIES();
+  DISPLAY_INI_ENTRIES();
 #endif
 }
 /* }}} */
@@ -92,46 +100,46 @@ static PHP_MINFO_FUNCTION(pdo_snowflake)
 /* {{{ PHP_GINIT_FUNCTION */
 static PHP_GINIT_FUNCTION(pdo_snowflake)
 {
-#if (PHP_VERSION_ID>=70000)
+#if (PHP_VERSION_ID >= 70000)
 #if defined(COMPILE_DL_PDO_SNOWFLAKE) && defined(ZTS)
-ZEND_TSRMLS_CACHE_UPDATE();
+  ZEND_TSRMLS_CACHE_UPDATE();
 #endif
 #endif
 #if PDO_DBG_ENABLED
-	pdo_snowflake_globals->debug = NULL;	/* The actual string */
+  pdo_snowflake_globals->debug = NULL;  /* The actual string */
 #endif
 }
 /* }}} */
 
 /* {{{ pdo_snowflake_functions[] */
 const zend_function_entry pdo_snowflake_functions[] = {
-	PHP_FE_END
+  PHP_FE_END
 };
 /* }}} */
 
 /* {{{ pdo_snowflake_deps[] */
 static const zend_module_dep pdo_snowflake_deps[] = {
-	ZEND_MOD_REQUIRED("pdo")
-	ZEND_MOD_END
+  ZEND_MOD_REQUIRED("pdo")
+  ZEND_MOD_END
 };
 /* }}} */
 
 /* {{{ pdo_snowflake_module_entry */
 zend_module_entry pdo_snowflake_module_entry = {
-	STANDARD_MODULE_HEADER_EX, NULL,
-	pdo_snowflake_deps,
-	"pdo_snowflake",
-	pdo_snowflake_functions,
-	PHP_MINIT(pdo_snowflake),
-	PHP_MSHUTDOWN(pdo_snowflake),
-	NULL,
-	NULL,
-	PHP_MINFO(pdo_snowflake),
-	PHP_PDO_SNOWFLAKE_VERSION,
-	PHP_MODULE_GLOBALS(pdo_snowflake),
-	PHP_GINIT(pdo_snowflake),
-	NULL,
-	NULL,
-	STANDARD_MODULE_PROPERTIES_EX
+  STANDARD_MODULE_HEADER_EX, NULL,
+  pdo_snowflake_deps,
+  "pdo_snowflake",
+  pdo_snowflake_functions,
+  PHP_MINIT(pdo_snowflake),
+  PHP_MSHUTDOWN(pdo_snowflake),
+  NULL,
+  NULL,
+  PHP_MINFO(pdo_snowflake),
+  PHP_PDO_SNOWFLAKE_VERSION,
+  PHP_MODULE_GLOBALS(pdo_snowflake),
+  PHP_GINIT(pdo_snowflake),
+  NULL,
+  NULL,
+  STANDARD_MODULE_PROPERTIES_EX
 };
 /* }}} */

--- a/php_pdo_snowflake_int.h
+++ b/php_pdo_snowflake_int.h
@@ -50,11 +50,10 @@ typedef struct {
 	pdo_snowflake_db_handle *H;
 	SNOWFLAKE_STMT          *stmt;
 	int64                   num_params;
-	SNOWFLAKE_BIND_INPUT    *params;
+	SNOWFLAKE_BIND_INPUT    *bound_params;
 	SNOWFLAKE_BIND_OUTPUT   *bound_result;
 	sf_bool					        *out_null;
 	zend_ulong				      *out_length;
-  void                   **data;
 } pdo_snowflake_stmt;
 
 extern pdo_driver_t pdo_snowflake_driver;


### PR DESCRIPTION
Used 2 space tab, etc formats for PDO codes. Will sync up about Snowflake client tomorrow.

Removed null termination for data binding. NULL termination won't work for data including NULL...