### PR TITLE
Fixed #35. Made SNOWFLAKE_STMT reusable for multiple queries

### DIFF
--- a/libsnowflakeclient/CMakeLists.txt
+++ b/libsnowflakeclient/CMakeLists.txt
@@ -8,7 +8,7 @@ project(snowflakeclient)
 add_definitions(-DLOG_USE_COLOR)
 
 set(CMAKE_VERBOSE_MAKEFILE ON)
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pthread -fPIC -Wall")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O2 -pthread -fPIC -Wall")
 
 set(SOURCE_FILES
         include

--- a/libsnowflakeclient/examples/CMakeLists.txt
+++ b/libsnowflakeclient/examples/CMakeLists.txt
@@ -11,7 +11,8 @@ SET(EXAMPLES
         select1
         transaction
         ping_pong
-        stmt_with_bad_connect)
+        stmt_with_bad_connect
+        crud)
 
 set(SOURCE_UTILS
         example_setup.c)

--- a/libsnowflakeclient/examples/crud.c
+++ b/libsnowflakeclient/examples/crud.c
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2017 Snowflake Computing, Inc. All rights reserved.
+ */
+
+#include <stdio.h>
+#include <snowflake_client.h>
+#include <example_setup.h>
+
+/**
+ * Example of simple CRUD
+ */
+int main() {
+    int ret = -1;
+    SNOWFLAKE_STATUS status;
+    initialize_snowflake_example(SF_BOOLEAN_FALSE);
+
+    /* Connect with all parameters set */
+    SNOWFLAKE *sf = setup_snowflake_connection();
+    status = snowflake_connect(sf);
+    if (status != SF_STATUS_SUCCESS) {
+        fprintf(stderr, "connecting to snowflake failed\n");
+        goto error_con;
+    }
+
+    /* Create a statement once and reused */
+    SNOWFLAKE_STMT *stmt = snowflake_stmt(sf);
+    /* NOTE: the numeric type here should fit into int64 otherwise
+     * it is taken as a float */
+    status = snowflake_query(
+      stmt,
+      "create or replace table t (c1 number(10,0), c2 string)");
+    if (status != SF_STATUS_SUCCESS) {
+        fprintf(stderr, "failed to create a table\n");
+        goto error_stmt;
+    }
+
+    status = snowflake_query(
+      stmt,
+      "insert into t values(1, 'test1'),(2, 'test2')"
+    );
+    if (status != SF_STATUS_SUCCESS) {
+        fprintf(stderr, "failed to insert a table\n");
+        goto error_stmt;
+    }
+
+    status = snowflake_query(
+      stmt,
+      "select * from t"
+    );
+    if (status != SF_STATUS_SUCCESS) {
+        fprintf(stderr, "failed to select a table\n");
+        goto error_stmt;
+    }
+    printf("len = %lld\n", stmt->total_fieldcount);
+
+    int64 c1v = 0;
+    SNOWFLAKE_BIND_OUTPUT c1;
+    c1.idx = 1;
+    c1.max_length = sizeof(c1v);
+    c1.type = SF_C_TYPE_INT64;
+    c1.value = &c1v;
+    status = snowflake_bind_result(stmt, &c1);
+    if (status != SF_STATUS_SUCCESS) {
+        fprintf(stderr, "failed to bind c1\n");
+        goto error_stmt;
+    }
+
+    char c2v[1000];
+    SNOWFLAKE_BIND_OUTPUT c2;
+    c2.idx = 2;
+    c2.max_length = sizeof(c2v);
+    c2.type = SF_C_TYPE_STRING;
+    c2.value = &c2v;
+    status = snowflake_bind_result(stmt, &c2);
+    if (status != SF_STATUS_SUCCESS) {
+        fprintf(stderr, "failed to bind c2\n");
+        goto error_stmt;
+    }
+
+    int64 total = 0;
+    while ((status = snowflake_fetch(stmt)) == SF_STATUS_SUCCESS) {
+        printf("c1: %d, c2: %s\n", c1v, c2v);
+        total += c1v;
+    }
+    if (total != 3) {
+        fprintf(
+          stderr,
+          "failed to get the all values. expected: 3, got :%lld", total);
+        goto error_stmt;
+    }
+
+    if (status != SF_STATUS_EOL) {
+        fprintf(stderr, "failed to fetch data\n");
+        goto error_stmt;
+    }
+    ret = 0;
+
+    error_stmt: /* error stmt */
+    snowflake_stmt_close(stmt);
+
+    error_con: /* error connection */
+    snowflake_close(sf);
+    snowflake_term(sf);
+    snowflake_global_term();
+    return ret;
+}

--- a/libsnowflakeclient/examples/select1.c
+++ b/libsnowflakeclient/examples/select1.c
@@ -24,13 +24,13 @@ int main() {
 
     /* query */
     SNOWFLAKE_STMT *sfstmt = snowflake_stmt(sf);
+    snowflake_query(sfstmt, "select 1;");
     SNOWFLAKE_BIND_OUTPUT c1;
     int64 out = 0;
     c1.idx = 1;
     c1.type = SF_C_TYPE_INT64;
     c1.value = (void *) &out;
     snowflake_bind_result(sfstmt, &c1);
-    snowflake_query(sfstmt, "select 1;");
     printf("Number of rows: %d\n", (int) snowflake_num_rows(sfstmt));
 
     while ((status = snowflake_fetch(sfstmt)) != SF_STATUS_EOL) {

--- a/libsnowflakeclient/examples/stmt_with_bad_connect.c
+++ b/libsnowflakeclient/examples/stmt_with_bad_connect.c
@@ -17,13 +17,13 @@ int main() {
 
     /* query, try running a query with a connection struct that has not connected */
     SNOWFLAKE_STMT *sfstmt = snowflake_stmt(sf);
+    snowflake_prepare(sfstmt, "select 1;");
     SNOWFLAKE_BIND_OUTPUT c1;
     int out = 0;
     c1.idx = 1;
     c1.type = SF_C_TYPE_INT64;
     c1.value = (void *) &out;
     snowflake_bind_result(sfstmt, &c1);
-    snowflake_prepare(sfstmt, "select 1;");
     status = snowflake_execute(sfstmt);
     if (status != SF_STATUS_SUCCESS) {
         SNOWFLAKE_ERROR *error = snowflake_stmt_error(sfstmt);

--- a/php_pdo_snowflake_int.h
+++ b/php_pdo_snowflake_int.h
@@ -8,11 +8,11 @@
 #if 1
 #define PDO_DBG_ENABLED 1
 
-#define PDO_DBG_INF(...) pdo_snowflake_log(__LINE__, __FILE__, "info", __VA_ARGS__)
-#define PDO_DBG_ERR(...) pdo_snowflake_log(__LINE__, __FILE__, "error", __VA_ARGS__)
-#define PDO_DBG_ENTER(func_name) pdo_snowflake_log(__LINE__, __FILE__, "enter", func_name)
-#define PDO_DBG_RETURN(value)  do { pdo_snowflake_log(__LINE__, __FILE__, "return", ""); return (value); } while (0)
-#define PDO_DBG_VOID_RETURN(value)  do { pdo_snowflake_log(__LINE__, __FILE__, "return", ""); return; } while (0)
+#define PDO_DBG_INF(...) pdo_snowflake_log(__LINE__, __FILE__, "INFO", __VA_ARGS__)
+#define PDO_DBG_ERR(...) pdo_snowflake_log(__LINE__, __FILE__, "ERROR", __VA_ARGS__)
+#define PDO_DBG_ENTER(func_name) pdo_snowflake_log(__LINE__, __FILE__, "E", func_name)
+#define PDO_DBG_RETURN(value)  do { pdo_snowflake_log(__LINE__, __FILE__, "R", ""); return (value); } while (0)
+#define PDO_DBG_VOID_RETURN(value)  do { pdo_snowflake_log(__LINE__, __FILE__, "R", ""); return; } while (0)
 #else
 #define PDO_DBG_ENABLED 0
 static inline void PDO_DBG_INF(char *format, ...) {}

--- a/snowflake_driver.c
+++ b/snowflake_driver.c
@@ -201,8 +201,10 @@ snowflake_handle_doer(pdo_dbh_t *dbh, const char *sql, size_t sql_len) /* {{{ */
 
     // TODO add debugging statements
 
+    PDO_DBG_INF("sql: %s, len: %d", sql, sql_len);
     SNOWFLAKE_STMT *sfstmt = snowflake_stmt(H->server);
     if (snowflake_query(sfstmt, sql) == SF_STATUS_SUCCESS) {
+        PDO_DBG_INF("success");
         int64 rows = snowflake_affected_rows(sfstmt);
         if (rows == -1) {
             pdo_stmt_t *pdostmt = ecalloc(1, sizeof(pdo_stmt_t));
@@ -214,11 +216,12 @@ snowflake_handle_doer(pdo_dbh_t *dbh, const char *sql, size_t sql_len) /* {{{ */
             ret = -1; // TODO add ternary expression like: H->einfo.errcode ? -1 : 0
             goto cleanup;
         }
+        PDO_DBG_INF("success1");
         // return number of rows affected
         ret = (int) rows;
     }
     else {
-        // TODO copy error from sfstmt to snowflake db handle
+        /* Failed to run a query */
         pdo_snowflake_error(dbh);
         ret = -1;
         goto cleanup;

--- a/snowflake_stmt.c
+++ b/snowflake_stmt.c
@@ -25,7 +25,7 @@ static int pdo_snowflake_stmt_dtor(pdo_stmt_t *stmt) /* {{{ */
     if (S->bound_params) {
         efree(S->bound_params);
     }
-    PDO_DBG_INF("COUNT: %d", stmt->column_count);
+    PDO_DBG_INF("count: %d", stmt->column_count);
     if (S->bound_result) {
         int i;
         for (i = 0; i < stmt->column_count; ++i) {

--- a/tests/connect.phpt
+++ b/tests/connect.phpt
@@ -1,5 +1,5 @@
 --TEST--
-PDO_SNOWFLAKE:
+pdo_snowflake - connect
 --FILE--
 <?php
     $p = parse_ini_file(getenv('PWD') . "/testenv.ini");


### PR DESCRIPTION
This change is to make SNOWFLAKE_STMT reusable.

The side effect is you no longer can bind columns *before* query/prepare, because they reset all status.
