### PR TITLE
Consistent naming

### DIFF
--- a/libsnowflakeclient/examples/connect.c
+++ b/libsnowflakeclient/examples/connect.c
@@ -11,10 +11,10 @@
 int main()
 {
     /* init */
-    SNOWFLAKE_STATUS status;
+    SF_STATUS status;
     initialize_snowflake_example(SF_BOOLEAN_FALSE);
 
-    SNOWFLAKE *sf = NULL;
+    SF_CONNECT *sf = NULL;
 
     // Try connecting with a NULL connection struct, should fail
     status = snowflake_connect(sf);
@@ -28,7 +28,7 @@ int main()
     sf = snowflake_init();
     status = snowflake_connect(sf);
     if (status != SF_STATUS_SUCCESS) {
-        SNOWFLAKE_ERROR *error = snowflake_error(sf);
+        SF_ERROR *error = snowflake_error(sf);
         printf("OK, connecting to snowflake failed. Error message: %s. In File, %s, Line, %d\n", error->msg, error->file, error->line);
     } else {
         fprintf(stderr, "Connecting to snowflake succeeded...exiting");
@@ -54,7 +54,7 @@ int main()
 
     status = snowflake_connect(sf);
     if (status != SF_STATUS_SUCCESS) {
-        SNOWFLAKE_ERROR *error = snowflake_error(sf);
+        SF_ERROR *error = snowflake_error(sf);
         fprintf(stderr, "Failed connecting with minimum parameters set.\n");
         fprintf(stderr, "Error message: %s\nIn File, %s, Line, %d\n", error->msg, error->file, error->line);
     } else {
@@ -67,7 +67,7 @@ int main()
 
     status = snowflake_connect(sf);
     if (status != SF_STATUS_SUCCESS) {
-        SNOWFLAKE_ERROR *error = snowflake_error(sf);
+        SF_ERROR *error = snowflake_error(sf);
         fprintf(stderr, "Failed connecting with full parameters set\n");
         fprintf(stderr, "Error message: %s\nIn File, %s, Line, %d\n", error->msg, error->file, error->line);
     } else {

--- a/libsnowflakeclient/examples/crud.c
+++ b/libsnowflakeclient/examples/crud.c
@@ -7,9 +7,9 @@
 #include <example_setup.h>
 #include <memory.h>
 
-int fetch_data(SNOWFLAKE_STMT *stmt, int64 expected_sum) {
+int fetch_data(SF_STMT *stmt, int64 expected_sum) {
     int ret = -1;
-    SNOWFLAKE_STATUS status;
+    SF_STATUS status;
 
     status = snowflake_query(
       stmt,
@@ -21,7 +21,7 @@ int fetch_data(SNOWFLAKE_STMT *stmt, int64 expected_sum) {
     }
 
     int64 c1v = 0;
-    SNOWFLAKE_BIND_OUTPUT c1;
+    SF_BIND_OUTPUT c1;
     c1.idx = 1;
     c1.max_length = sizeof(c1v);
     c1.type = SF_C_TYPE_INT64;
@@ -33,7 +33,7 @@ int fetch_data(SNOWFLAKE_STMT *stmt, int64 expected_sum) {
     }
 
     char c2v[1000];
-    SNOWFLAKE_BIND_OUTPUT c2;
+    SF_BIND_OUTPUT c2;
     c2.idx = 2;
     c2.max_length = sizeof(c2v);
     c2.type = SF_C_TYPE_STRING;
@@ -71,11 +71,11 @@ int fetch_data(SNOWFLAKE_STMT *stmt, int64 expected_sum) {
  */
 int main() {
     int ret = -1;
-    SNOWFLAKE_STATUS status;
+    SF_STATUS status;
     initialize_snowflake_example(SF_BOOLEAN_FALSE);
 
     /* Connect with all parameters set */
-    SNOWFLAKE *sf = setup_snowflake_connection();
+    SF_CONNECT *sf = setup_snowflake_connection();
     status = snowflake_connect(sf);
     if (status != SF_STATUS_SUCCESS) {
         fprintf(stderr, "connecting to snowflake failed\n");
@@ -83,7 +83,7 @@ int main() {
     }
 
     /* Create a statement once and reused */
-    SNOWFLAKE_STMT *stmt = snowflake_stmt(sf);
+    SF_STMT *stmt = snowflake_stmt(sf);
     /* NOTE: the numeric type here should fit into int64 otherwise
      * it is taken as a float */
     status = snowflake_query(
@@ -115,7 +115,7 @@ int main() {
     }
 
     int64 p1v = 102;
-    SNOWFLAKE_BIND_INPUT p1;
+    SF_BIND_INPUT p1;
     p1.idx = 1;
     p1.c_type = SF_C_TYPE_INT64;
     p1.value = &p1v;
@@ -127,7 +127,7 @@ int main() {
 
     char p2v[1000];
     strcpy(p2v, "test2");
-    SNOWFLAKE_BIND_INPUT p2;
+    SF_BIND_INPUT p2;
     p2.idx = 2;
     p2.c_type = SF_C_TYPE_STRING;
     p2.value = &p2v;

--- a/libsnowflakeclient/examples/example_setup.c
+++ b/libsnowflakeclient/examples/example_setup.c
@@ -11,8 +11,8 @@ void initialize_snowflake_example(sf_bool debug) {
     snowflake_global_set_attribute(SF_GLOBAL_DEBUG, &debug);
 }
 
-SNOWFLAKE *setup_snowflake_connection() {
-    SNOWFLAKE *sf = snowflake_init();
+SF_CONNECT *setup_snowflake_connection() {
+    SF_CONNECT *sf = snowflake_init();
 
     snowflake_set_attr(sf, SF_CON_ACCOUNT, getenv("SNOWFLAKE_TEST_ACCOUNT"));
     snowflake_set_attr(sf, SF_CON_USER, getenv("SNOWFLAKE_TEST_USER"));

--- a/libsnowflakeclient/examples/ping_pong.c
+++ b/libsnowflakeclient/examples/ping_pong.c
@@ -10,15 +10,15 @@
 
 int main() {
     /* init */
-    SNOWFLAKE_STATUS status;
-    SNOWFLAKE *sf = NULL;
-    SNOWFLAKE_STMT *sfstmt = NULL;
+    SF_STATUS status;
+    SF_CONNECT *sf = NULL;
+    SF_STMT *sfstmt = NULL;
     initialize_snowflake_example(SF_BOOLEAN_FALSE);
     sf = setup_snowflake_connection();
     status = snowflake_connect(sf);
     if (status != SF_STATUS_SUCCESS) {
         fprintf(stderr, "Connecting to snowflake failed, exiting...\n");
-        SNOWFLAKE_ERROR *error = snowflake_error(sf);
+        SF_ERROR *error = snowflake_error(sf);
         fprintf(stderr, "Error message: %s\nIn File, %s, Line, %d\n", error->msg, error->file, error->line);
         goto cleanup;
     } else {
@@ -29,7 +29,7 @@ int main() {
     sfstmt = snowflake_stmt(sf);
     status = snowflake_query(sfstmt, "select seq4() from table(generator(timelimit=>60));");
     if (status != SF_STATUS_SUCCESS) {
-        SNOWFLAKE_ERROR *error = snowflake_stmt_error(sfstmt);
+        SF_ERROR *error = snowflake_stmt_error(sfstmt);
         fprintf(stderr, "Error message: %s\nIn File, %s, Line, %d\n", error->msg, error->file, error->line);
     }
     printf("Number of rows: %d\n", (int) snowflake_num_rows(sfstmt));

--- a/libsnowflakeclient/examples/select1.c
+++ b/libsnowflakeclient/examples/select1.c
@@ -11,21 +11,21 @@
 
 int main() {
     /* init */
-    SNOWFLAKE_STATUS status;
+    SF_STATUS status;
     initialize_snowflake_example(SF_BOOLEAN_FALSE);
-    SNOWFLAKE *sf = setup_snowflake_connection();
+    SF_CONNECT *sf = setup_snowflake_connection();
     status = snowflake_connect(sf);
     if (status != SF_STATUS_SUCCESS) {
         fprintf(stderr, "Connecting to snowflake failed, exiting...\n");
-        SNOWFLAKE_ERROR *error = snowflake_error(sf);
+        SF_ERROR *error = snowflake_error(sf);
         fprintf(stderr, "Error message: %s\nIn File, %s, Line, %d\n", error->msg, error->file, error->line);
         goto cleanup;
     }
 
     /* query */
-    SNOWFLAKE_STMT *sfstmt = snowflake_stmt(sf);
+    SF_STMT *sfstmt = snowflake_stmt(sf);
     snowflake_query(sfstmt, "select 1;");
-    SNOWFLAKE_BIND_OUTPUT c1;
+    SF_BIND_OUTPUT c1;
     int64 out = 0;
     c1.idx = 1;
     c1.type = SF_C_TYPE_INT64;
@@ -35,7 +35,7 @@ int main() {
 
     while ((status = snowflake_fetch(sfstmt)) != SF_STATUS_EOL) {
         if (status == SF_STATUS_ERROR || status == SF_STATUS_WARNING) {
-            SNOWFLAKE_ERROR *error = snowflake_stmt_error(sfstmt);
+            SF_ERROR *error = snowflake_stmt_error(sfstmt);
             fprintf(stderr, "Error message: %s\nIn File, %s, Line, %d\n", error->msg, error->file, error->line);
             break;
         }

--- a/libsnowflakeclient/examples/stmt_with_bad_connect.c
+++ b/libsnowflakeclient/examples/stmt_with_bad_connect.c
@@ -11,14 +11,14 @@
 
 int main() {
     /* init */
-    SNOWFLAKE_STATUS status;
+    SF_STATUS status;
     initialize_snowflake_example(SF_BOOLEAN_FALSE);
-    SNOWFLAKE *sf = snowflake_init();
+    SF_CONNECT *sf = snowflake_init();
 
     /* query, try running a query with a connection struct that has not connected */
-    SNOWFLAKE_STMT *sfstmt = snowflake_stmt(sf);
+    SF_STMT *sfstmt = snowflake_stmt(sf);
     snowflake_prepare(sfstmt, "select 1;");
-    SNOWFLAKE_BIND_OUTPUT c1;
+    SF_BIND_OUTPUT c1;
     int out = 0;
     c1.idx = 1;
     c1.type = SF_C_TYPE_INT64;
@@ -26,7 +26,7 @@ int main() {
     snowflake_bind_result(sfstmt, &c1);
     status = snowflake_execute(sfstmt);
     if (status != SF_STATUS_SUCCESS) {
-        SNOWFLAKE_ERROR *error = snowflake_stmt_error(sfstmt);
+        SF_ERROR *error = snowflake_stmt_error(sfstmt);
         printf("OK, running query to snowflake failed. Error message: %s. In File, %s, Line, %d\n", error->msg, error->file, error->line);
     } else {
         fprintf(stderr, "Running query succeeded...exiting");
@@ -52,7 +52,7 @@ int main() {
     }
     status = snowflake_connect(sf);
     if (status != SF_STATUS_SUCCESS) {
-        SNOWFLAKE_ERROR *error = snowflake_error(sf);
+        SF_ERROR *error = snowflake_error(sf);
         fprintf(stderr, "Failed connecting with minimum parameters set.\n");
         fprintf(stderr, "Error message: %s\nIn File, %s, Line, %d\n", error->msg, error->file, error->line);
         
@@ -63,7 +63,7 @@ int main() {
     // Retry query now that connection works
     status = snowflake_execute(sfstmt);
     if (status != SF_STATUS_SUCCESS) {
-        SNOWFLAKE_ERROR *error = snowflake_stmt_error(sfstmt);
+        SF_ERROR *error = snowflake_stmt_error(sfstmt);
         fprintf(stderr, "Failed running query with connect snowflake object.\n");
         fprintf(stderr, "Error message: %s\nIn File, %s, Line, %d\n", error->msg, error->file, error->line);
     } else {
@@ -73,7 +73,7 @@ int main() {
 
     while ((status = snowflake_fetch(sfstmt)) != SF_STATUS_EOL) {
         if (status == SF_STATUS_ERROR || status == SF_STATUS_WARNING) {
-            SNOWFLAKE_ERROR *error = snowflake_stmt_error(sfstmt);
+            SF_ERROR *error = snowflake_stmt_error(sfstmt);
             fprintf(stderr, "Error message: %s\nIn File, %s, Line, %d\n", error->msg, error->file, error->line);
             break;
         }

--- a/libsnowflakeclient/examples/transaction.c
+++ b/libsnowflakeclient/examples/transaction.c
@@ -10,9 +10,9 @@
 
 int main()
 {
-  SNOWFLAKE_ERROR *err;
+  SF_ERROR *err;
   /* init */
-  SNOWFLAKE *sf = snowflake_init();
+  SF_CONNECT *sf = snowflake_init();
 
   /* connect*/
   snowflake_set_attr(sf, SF_CON_HOST, getenv("SNOWFLAKE_TEST_HOST"));
@@ -31,9 +31,9 @@ int main()
   snowflake_trans_begin(sf);
 
   /* execute a DML */
-  SNOWFLAKE_STMT *sfstmt = snowflake_stmt(sf);
+  SF_STMT *sfstmt = snowflake_stmt(sf);
   snowflake_prepare(sfstmt, "INSERT INTO testtable(1,?,?)");
-  SNOWFLAKE_BIND_INPUT p1, p2;
+  SF_BIND_INPUT p1, p2;
   p1.idx = 1;
   p1.c_type = SF_C_TYPE_STRING;
   p1.value = (void *) "test1";
@@ -54,7 +54,7 @@ int main()
 
   err: /* error */
   snowflake_trans_rollback(sf);
-  /* SNOWFLAKE_ERROR structure is included in a SNOWFLAKE_STMT, so you don't
+  /* SF_ERROR structure is included in a SF_STMT, so you don't
    * need to free the memory. */
   err = snowflake_error(sfstmt);
   printf("Error. Query ID: %s, Message: %s\n", err->sfqid, err->msg);

--- a/libsnowflakeclient/examples/utils/example_setup.h
+++ b/libsnowflakeclient/examples/utils/example_setup.h
@@ -18,7 +18,7 @@ extern "C" {
 #include <snowflake_client.h>
 
 void initialize_snowflake_example(sf_bool debug);
-SNOWFLAKE *setup_snowflake_connection();
+SF_CONNECT *setup_snowflake_connection();
 
 #ifdef __cplusplus
 }

--- a/libsnowflakeclient/lib/connection.c
+++ b/libsnowflakeclient/lib/connection.c
@@ -113,7 +113,7 @@ static uint32 uimax(uint32 a, uint32 b) {
 }
 
 
-cJSON *STDCALL create_auth_json_body(SNOWFLAKE *sf,
+cJSON *STDCALL create_auth_json_body(SF_CONNECT *sf,
                                      const char *application,
                                      const char *int_app_name,
                                      const char *int_app_version) {
@@ -185,15 +185,15 @@ struct curl_slist * STDCALL create_header_token(const char *header_token) {
     return header;
 }
 
-sf_bool STDCALL curl_post_call(SNOWFLAKE *sf,
+sf_bool STDCALL curl_post_call(SF_CONNECT *sf,
                                CURL *curl,
                                char *url,
                                struct curl_slist *header,
                                char *body,
                                cJSON **json,
-                               SNOWFLAKE_ERROR *error) {
+                               SF_ERROR *error) {
     const char *error_msg;
-    SNOWFLAKE_JSON_ERROR json_error;
+    SF_JSON_ERROR json_error;
     char query_code[QUERYCODE_LEN];
     char *result_url = NULL;
     cJSON *data = NULL;
@@ -211,7 +211,7 @@ sf_bool STDCALL curl_post_call(SNOWFLAKE *sf,
             // Error is set in the perform function
             break;
         }
-        if ((json_error = json_copy_string_no_alloc(query_code, *json, "code", QUERYCODE_LEN)) != SF_JSON_NO_ERROR &&
+        if ((json_error = json_copy_string_no_alloc(query_code, *json, "code", QUERYCODE_LEN)) != SF_JSON_ERROR_NONE &&
                 json_error != SF_JSON_ERROR_ITEM_NULL) {
             JSON_ERROR_MSG(json_error, error_msg, "Query code");
             SET_SNOWFLAKE_ERROR(error, SF_ERROR_BAD_JSON, error_msg, "");
@@ -252,7 +252,7 @@ sf_bool STDCALL curl_post_call(SNOWFLAKE *sf,
             SF_FREE(result_url);
             memset(query_code, 0, QUERYCODE_LEN);
             data = cJSON_GetObjectItem(*json, "data");
-            if (json_copy_string(&result_url, data, "getResultUrl") != SF_JSON_NO_ERROR) {
+            if (json_copy_string(&result_url, data, "getResultUrl") != SF_JSON_ERROR_NONE) {
                 stop = SF_BOOLEAN_TRUE;
                 JSON_ERROR_MSG(json_error, error_msg, "Result URL");
                 SET_SNOWFLAKE_ERROR(error, SF_ERROR_BAD_JSON, error_msg, "");
@@ -266,7 +266,7 @@ sf_bool STDCALL curl_post_call(SNOWFLAKE *sf,
                 break;
             }
 
-            if ((json_error = json_copy_string_no_alloc(query_code, *json, "code", QUERYCODE_LEN)) != SF_JSON_NO_ERROR &&
+            if ((json_error = json_copy_string_no_alloc(query_code, *json, "code", QUERYCODE_LEN)) != SF_JSON_ERROR_NONE &&
                 json_error != SF_JSON_ERROR_ITEM_NULL) {
                 stop = SF_BOOLEAN_TRUE;
                 JSON_ERROR_MSG(json_error, error_msg, "Query code");
@@ -289,13 +289,13 @@ sf_bool STDCALL curl_post_call(SNOWFLAKE *sf,
     return ret;
 }
 
-sf_bool STDCALL curl_get_call(SNOWFLAKE *sf,
+sf_bool STDCALL curl_get_call(SF_CONNECT *sf,
                               CURL *curl,
                               char *url,
                               struct curl_slist *header,
                               cJSON **json,
-                              SNOWFLAKE_ERROR *error) {
-    SNOWFLAKE_JSON_ERROR json_error;
+                              SF_ERROR *error) {
+    SF_JSON_ERROR json_error;
     const char *error_msg;
     char query_code[QUERYCODE_LEN];
     char *result_url = NULL;
@@ -312,7 +312,7 @@ sf_bool STDCALL curl_get_call(SNOWFLAKE *sf,
             // Error is set in the perform function
             break;
         }
-        if ((json_error = json_copy_string_no_alloc(query_code, *json, "code", QUERYCODE_LEN)) != SF_JSON_NO_ERROR &&
+        if ((json_error = json_copy_string_no_alloc(query_code, *json, "code", QUERYCODE_LEN)) != SF_JSON_ERROR_NONE &&
             json_error != SF_JSON_ERROR_ITEM_NULL) {
             JSON_ERROR_MSG(json_error, error_msg, "Query code");
             SET_SNOWFLAKE_ERROR(error, SF_ERROR_BAD_JSON, error_msg, "");
@@ -381,7 +381,7 @@ char * encode_url(CURL *curl,
                   const char *url,
                   URL_KEY_VALUE* vars,
                   int num_args,
-                  SNOWFLAKE_ERROR *error) {
+                  SF_ERROR *error) {
     int i;
     sf_bool host_empty = is_string_empty(host);
     sf_bool port_empty = is_string_empty(port);
@@ -462,7 +462,7 @@ sf_bool is_string_empty(const char *str) {
     return (str && strcmp(str, "") != 0) ? SF_BOOLEAN_FALSE : SF_BOOLEAN_TRUE;
 }
 
-SNOWFLAKE_JSON_ERROR STDCALL json_copy_string(char **dest, cJSON *data, const char *item) {
+SF_JSON_ERROR STDCALL json_copy_string(char **dest, cJSON *data, const char *item) {
     size_t blob_size;
     cJSON *blob = cJSON_GetObjectItem(data, item);
     if (!blob) {
@@ -482,10 +482,10 @@ SNOWFLAKE_JSON_ERROR STDCALL json_copy_string(char **dest, cJSON *data, const ch
         log_debug("Found item and value; %s: %s", item, *dest);
     }
 
-    return SF_JSON_NO_ERROR;
+    return SF_JSON_ERROR_NONE;
 }
 
-SNOWFLAKE_JSON_ERROR STDCALL json_copy_string_no_alloc(char *dest, cJSON *data, const char *item, size_t dest_size) {
+SF_JSON_ERROR STDCALL json_copy_string_no_alloc(char *dest, cJSON *data, const char *item, size_t dest_size) {
     cJSON *blob = cJSON_GetObjectItem(data, item);
     if (!blob) {
         return SF_JSON_ERROR_ITEM_MISSING;
@@ -502,10 +502,10 @@ SNOWFLAKE_JSON_ERROR STDCALL json_copy_string_no_alloc(char *dest, cJSON *data, 
         log_debug("Found item and value; %s: %s", item, dest);
     }
 
-    return SF_JSON_NO_ERROR;
+    return SF_JSON_ERROR_NONE;
 }
 
-SNOWFLAKE_JSON_ERROR STDCALL json_copy_bool(sf_bool *dest, cJSON *data, const char *item) {
+SF_JSON_ERROR STDCALL json_copy_bool(sf_bool *dest, cJSON *data, const char *item) {
     cJSON *blob = cJSON_GetObjectItem(data, item);
     if (!blob) {
         return SF_JSON_ERROR_ITEM_MISSING;
@@ -518,10 +518,10 @@ SNOWFLAKE_JSON_ERROR STDCALL json_copy_bool(sf_bool *dest, cJSON *data, const ch
         log_debug("Found item and value; %s: %i", item, *dest);
     }
 
-    return SF_JSON_NO_ERROR;
+    return SF_JSON_ERROR_NONE;
 }
 
-SNOWFLAKE_JSON_ERROR STDCALL json_copy_int(int64 *dest, cJSON *data, const char *item) {
+SF_JSON_ERROR STDCALL json_copy_int(int64 *dest, cJSON *data, const char *item) {
     cJSON *blob = cJSON_GetObjectItem(data, item);
     if (!blob) {
         return SF_JSON_ERROR_ITEM_MISSING;
@@ -534,10 +534,10 @@ SNOWFLAKE_JSON_ERROR STDCALL json_copy_int(int64 *dest, cJSON *data, const char 
         log_debug("Found item and value; %s: %i", item, *dest);
     }
 
-    return SF_JSON_NO_ERROR;
+    return SF_JSON_ERROR_NONE;
 }
 
-SNOWFLAKE_JSON_ERROR STDCALL json_detach_array_from_object(cJSON **dest, cJSON *data, const char *item) {
+SF_JSON_ERROR STDCALL json_detach_array_from_object(cJSON **dest, cJSON *data, const char *item) {
     cJSON *blob = cJSON_DetachItemFromObject(data, item);
     if (!blob) {
         return SF_JSON_ERROR_ITEM_MISSING;
@@ -553,10 +553,10 @@ SNOWFLAKE_JSON_ERROR STDCALL json_detach_array_from_object(cJSON **dest, cJSON *
         log_debug("Found array item: %s", item);
     }
 
-    return SF_JSON_NO_ERROR;
+    return SF_JSON_ERROR_NONE;
 }
 
-SNOWFLAKE_JSON_ERROR STDCALL json_detach_array_from_array(cJSON **dest, cJSON *data, int index) {
+SF_JSON_ERROR STDCALL json_detach_array_from_array(cJSON **dest, cJSON *data, int index) {
     cJSON *blob = cJSON_DetachItemFromArray(data, index);
     if (!blob) {
         return SF_JSON_ERROR_ITEM_MISSING;
@@ -572,7 +572,7 @@ SNOWFLAKE_JSON_ERROR STDCALL json_detach_array_from_array(cJSON **dest, cJSON *d
         log_debug("Found array item at index: %s", index);
     }
 
-    return SF_JSON_NO_ERROR;
+    return SF_JSON_ERROR_NONE;
 }
 
 /**
@@ -590,14 +590,14 @@ size_t json_resp_cb(char *data, size_t size, size_t nmemb, RAW_JSON_BUFFER *raw_
     return data_size;
 }
 
-sf_bool STDCALL http_perform(SNOWFLAKE *sf,
+sf_bool STDCALL http_perform(SF_CONNECT *sf,
                              CURL *curl,
-                             SNOWFLAKE_REQUEST_TYPE request_type,
+                             SF_REQUEST_TYPE request_type,
                              char *url,
                              struct curl_slist *header,
                              char *body,
                              cJSON **json,
-                             SNOWFLAKE_ERROR *error) {
+                             SF_ERROR *error) {
     CURLcode res;
     sf_bool ret = SF_BOOLEAN_FALSE;
     sf_bool retry = SF_BOOLEAN_FALSE;
@@ -749,15 +749,15 @@ sf_bool STDCALL is_retryable_http_code(int32 code) {
     return ((code >= 500 && code < 600) || code == 400 || code == 403 || code == 408) ? SF_BOOLEAN_TRUE : SF_BOOLEAN_FALSE;
 }
 
-sf_bool STDCALL request(SNOWFLAKE *sf,
+sf_bool STDCALL request(SF_CONNECT *sf,
                         cJSON **json,
                         const char *url,
                         URL_KEY_VALUE* url_params,
                         int num_url_params,
                         char *body,
                         struct curl_slist *header,
-                        SNOWFLAKE_REQUEST_TYPE request_type,
-                        SNOWFLAKE_ERROR *error) {
+                        SF_REQUEST_TYPE request_type,
+                        SF_ERROR *error) {
     sf_bool ret = SF_BOOLEAN_FALSE;
     CURL *curl = NULL;
     char *encoded_url = NULL;
@@ -817,9 +817,9 @@ cleanup:
     return ret;
 }
 
-sf_bool STDCALL renew_session(CURL *curl, SNOWFLAKE *sf, SNOWFLAKE_ERROR *error) {
+sf_bool STDCALL renew_session(CURL *curl, SF_CONNECT *sf, SF_ERROR *error) {
     sf_bool ret = SF_BOOLEAN_FALSE;
-    SNOWFLAKE_JSON_ERROR json_error;
+    SF_JSON_ERROR json_error;
     const char *error_msg = NULL;
     char request_id[UUID4_LEN];
     struct curl_slist *header = NULL;
@@ -933,11 +933,11 @@ uint32 STDCALL retry_ctx_next_sleep(RETRY_CONTEXT *retry_ctx) {
     return retry_ctx->sleep_time;
 }
 
-sf_bool STDCALL set_tokens(SNOWFLAKE *sf,
+sf_bool STDCALL set_tokens(SF_CONNECT *sf,
                            cJSON *data,
                            const char *session_token_str,
                            const char *master_token_str,
-                           SNOWFLAKE_ERROR *error) {
+                           SF_ERROR *error) {
     // Get token
     if (json_copy_string(&sf->token, data, session_token_str)) {
         log_error("No valid token found in response");

--- a/libsnowflakeclient/lib/connection.h
+++ b/libsnowflakeclient/lib/connection.h
@@ -35,15 +35,15 @@ typedef enum sf_request_type {
 
             /** we are doing a http delete */
             DELETE_REQUEST_TYPE,
-} SNOWFLAKE_REQUEST_TYPE;
+} SF_REQUEST_TYPE;
 
 typedef enum sf_json_errors {
-    SF_JSON_NO_ERROR,
+    SF_JSON_ERROR_NONE,
     SF_JSON_ERROR_ITEM_MISSING,
     SF_JSON_ERROR_ITEM_WRONG_TYPE,
     SF_JSON_ERROR_ITEM_NULL,
     SF_JSON_ERROR_OOM
-} SNOWFLAKE_JSON_ERROR;
+} SF_JSON_ERROR;
 
 typedef struct sf_raw_json_buffer {
     char *buffer;
@@ -92,7 +92,7 @@ static void dump(const char *text, FILE *stream, unsigned char *ptr, size_t size
 static int my_trace(CURL *handle, curl_infotype type, char *data, size_t size, void *userp);
 
 
-cJSON *STDCALL create_auth_json_body(SNOWFLAKE *sf,
+cJSON *STDCALL create_auth_json_body(SF_CONNECT *sf,
                                      const char *application,
                                      const char *int_app_name,
                                      const char *int_app_version);
@@ -100,19 +100,19 @@ cJSON *STDCALL create_query_json_body(const char *sql_text, int64 sequence_id);
 cJSON *STDCALL create_renew_session_json_body(const char *old_token);
 struct curl_slist * STDCALL create_header_no_token();
 struct curl_slist * STDCALL create_header_token(const char *header_token);
-sf_bool STDCALL curl_post_call(SNOWFLAKE *sf,
+sf_bool STDCALL curl_post_call(SF_CONNECT *sf,
                                CURL *curl,
                                char *url,
                                struct curl_slist *header,
                                char *body,
                                cJSON **json,
-                               SNOWFLAKE_ERROR *error);
-sf_bool STDCALL curl_get_call(SNOWFLAKE *sf,
+                               SF_ERROR *error);
+sf_bool STDCALL curl_get_call(SF_CONNECT *sf,
                               CURL *curl,
                               char *url,
                               struct curl_slist *header,
                               cJSON **json,
-                              SNOWFLAKE_ERROR *error);
+                              SF_ERROR *error);
 uint32 decorrelate_jitter_next_sleep(DECORRELATE_JITTER_BACKOFF *djb, uint32 sleep);
 char * STDCALL encode_url(CURL *curl,
                           const char *protocol,
@@ -122,40 +122,40 @@ char * STDCALL encode_url(CURL *curl,
                           const char *url,
                           URL_KEY_VALUE* vars,
                           int num_args,
-                          SNOWFLAKE_ERROR *error);
+                          SF_ERROR *error);
 sf_bool is_string_empty(const char * str);
-SNOWFLAKE_JSON_ERROR STDCALL json_copy_bool(sf_bool *dest, cJSON *data, const char *item);
-SNOWFLAKE_JSON_ERROR STDCALL json_copy_int(int64 *dest, cJSON *data, const char *item);
-SNOWFLAKE_JSON_ERROR STDCALL json_copy_string(char **dest, cJSON *data, const char *item);
-SNOWFLAKE_JSON_ERROR STDCALL json_copy_string_no_alloc(char *dest, cJSON *data, const char *item, size_t dest_size);
-SNOWFLAKE_JSON_ERROR STDCALL json_detach_array_from_object(cJSON **dest, cJSON *data, const char *item);
-SNOWFLAKE_JSON_ERROR STDCALL json_detach_array_from_array(cJSON **dest, cJSON *data, int index);
+SF_JSON_ERROR STDCALL json_copy_bool(sf_bool *dest, cJSON *data, const char *item);
+SF_JSON_ERROR STDCALL json_copy_int(int64 *dest, cJSON *data, const char *item);
+SF_JSON_ERROR STDCALL json_copy_string(char **dest, cJSON *data, const char *item);
+SF_JSON_ERROR STDCALL json_copy_string_no_alloc(char *dest, cJSON *data, const char *item, size_t dest_size);
+SF_JSON_ERROR STDCALL json_detach_array_from_object(cJSON **dest, cJSON *data, const char *item);
+SF_JSON_ERROR STDCALL json_detach_array_from_array(cJSON **dest, cJSON *data, int index);
 size_t json_resp_cb(char *data, size_t size, size_t nmemb, RAW_JSON_BUFFER *raw_json);
-sf_bool STDCALL http_perform(SNOWFLAKE *sf,
+sf_bool STDCALL http_perform(SF_CONNECT *sf,
                              CURL *curl,
-                             SNOWFLAKE_REQUEST_TYPE request_type,
+                             SF_REQUEST_TYPE request_type,
                              char *url,
                              struct curl_slist *header,
                              char *body, cJSON **json,
-                             SNOWFLAKE_ERROR *error);
+                             SF_ERROR *error);
 sf_bool STDCALL is_retryable_http_code(int32 code);
-sf_bool STDCALL renew_session(CURL * curl, SNOWFLAKE *sf, SNOWFLAKE_ERROR *error);
-sf_bool STDCALL request(SNOWFLAKE *sf,
+sf_bool STDCALL renew_session(CURL * curl, SF_CONNECT *sf, SF_ERROR *error);
+sf_bool STDCALL request(SF_CONNECT *sf,
                         cJSON **json,
                         const char *url,
                         URL_KEY_VALUE* url_params,
                         int num_url_params,
                         char *body,
                         struct curl_slist *header,
-                        SNOWFLAKE_REQUEST_TYPE request_type,
-                        SNOWFLAKE_ERROR *error);
+                        SF_REQUEST_TYPE request_type,
+                        SF_ERROR *error);
 void STDCALL reset_curl(CURL *curl);
 uint32 STDCALL retry_ctx_next_sleep(RETRY_CONTEXT *retry_ctx);
-sf_bool STDCALL set_tokens(SNOWFLAKE *sf,
+sf_bool STDCALL set_tokens(SF_CONNECT *sf,
                            cJSON *data,
                            const char *session_token_str,
                            const char *master_token_str,
-                           SNOWFLAKE_ERROR *error);
+                           SF_ERROR *error);
 
 #ifdef __cplusplus
 }

--- a/libsnowflakeclient/lib/error.c
+++ b/libsnowflakeclient/lib/error.c
@@ -6,8 +6,8 @@
 #include "error.h"
 #include "snowflake_memory.h"
 
-void STDCALL set_snowflake_error(SNOWFLAKE_ERROR *error,
-                                  SNOWFLAKE_ERROR_CODE error_code,
+void STDCALL set_snowflake_error(SF_ERROR *error,
+                                  SF_ERROR_CODE error_code,
                                   const char *msg,
                                   const char *sfqid,
                                   const char *file,
@@ -28,8 +28,8 @@ void STDCALL set_snowflake_error(SNOWFLAKE_ERROR *error,
     error->line = line;
 }
 
-void STDCALL clear_snowflake_error(SNOWFLAKE_ERROR *error) {
-    error->error_code = SF_NO_ERROR;
+void STDCALL clear_snowflake_error(SF_ERROR *error) {
+    error->error_code = SF_ERROR_NONE;
     error->msg = NULL;
     error->file = NULL;
     error->line = 0;

--- a/libsnowflakeclient/lib/error.h
+++ b/libsnowflakeclient/lib/error.h
@@ -19,13 +19,13 @@ extern "C" {
 
 #define SET_SNOWFLAKE_ERROR(e, ec, m, s) set_snowflake_error(e, ec, m, s, __FILE__, __LINE__)
 
-void STDCALL set_snowflake_error(SNOWFLAKE_ERROR *error,
-                                  SNOWFLAKE_ERROR_CODE error_code,
+void STDCALL set_snowflake_error(SF_ERROR *error,
+                                  SF_ERROR_CODE error_code,
                                   const char *msg,
                                   const char *sfqid,
                                   const char *file,
                                   int line);
-void STDCALL clear_snowflake_error(SNOWFLAKE_ERROR *error);
+void STDCALL clear_snowflake_error(SF_ERROR *error);
 
 #ifdef __cplusplus
 }

--- a/libsnowflakeclient/lib/results.c
+++ b/libsnowflakeclient/lib/results.c
@@ -8,7 +8,7 @@
 #include "snowflake_memory.h"
 #include <log.h>
 
-SNOWFLAKE_TYPE string_to_snowflake_type(const char *string) {
+SF_TYPE string_to_snowflake_type(const char *string) {
     if (strcmp(string, "fixed") == 0) {
         return SF_TYPE_FIXED;
     } else if (strcmp(string, "real") == 0) {
@@ -41,7 +41,7 @@ SNOWFLAKE_TYPE string_to_snowflake_type(const char *string) {
     }
 }
 
-const char *snowflake_type_to_string(SNOWFLAKE_TYPE type) {
+const char *snowflake_type_to_string(SF_TYPE type) {
     switch (type) {
         case SF_TYPE_FIXED:
             return "FIXED";
@@ -74,7 +74,7 @@ const char *snowflake_type_to_string(SNOWFLAKE_TYPE type) {
     }
 }
 
-SNOWFLAKE_C_TYPE snowflake_to_c_type(SNOWFLAKE_TYPE type, int64 precision, int64 scale) {
+SF_C_TYPE snowflake_to_c_type(SF_TYPE type, int64 precision, int64 scale) {
     if (type == SF_TYPE_FIXED) {
         if (scale > 0 || precision >= 19) {
             return SF_C_TYPE_FLOAT64;
@@ -98,7 +98,7 @@ SNOWFLAKE_C_TYPE snowflake_to_c_type(SNOWFLAKE_TYPE type, int64 precision, int64
     }
 }
 
-SNOWFLAKE_TYPE c_type_to_snowflake(SNOWFLAKE_C_TYPE c_type, SNOWFLAKE_TYPE tsmode) {
+SF_TYPE c_type_to_snowflake(SF_C_TYPE c_type, SF_TYPE tsmode) {
     switch (c_type) {
         case SF_C_TYPE_INT8:
             return SF_TYPE_FIXED;
@@ -119,7 +119,7 @@ SNOWFLAKE_TYPE c_type_to_snowflake(SNOWFLAKE_C_TYPE c_type, SNOWFLAKE_TYPE tsmod
     }
 }
 
-char *value_to_string(void *value, SNOWFLAKE_C_TYPE c_type) {
+char *value_to_string(void *value, SF_C_TYPE c_type) {
     size_t size;
     char *ret;
     // TODO turn cases into macro and check to see if ret if null
@@ -166,19 +166,19 @@ char *value_to_string(void *value, SNOWFLAKE_C_TYPE c_type) {
     }
 }
 
-SNOWFLAKE_COLUMN_DESC ** set_description(const cJSON *rowtype) {
+SF_COLUMN_DESC ** set_description(const cJSON *rowtype) {
     int i;
     cJSON *blob;
     cJSON *column;
-    SNOWFLAKE_COLUMN_DESC **desc = NULL;
+    SF_COLUMN_DESC **desc = NULL;
     size_t array_size = (size_t) cJSON_GetArraySize(rowtype);
     if (rowtype == NULL || array_size == 0) {
         return desc;
     }
-    desc = (SNOWFLAKE_COLUMN_DESC **) SF_CALLOC(array_size, sizeof(SNOWFLAKE_COLUMN_DESC *));
+    desc = (SF_COLUMN_DESC **) SF_CALLOC(array_size, sizeof(SF_COLUMN_DESC *));
     for (i = 0; i < array_size; i++) {
         column = cJSON_GetArrayItem(rowtype, i);
-        desc[i] = (SNOWFLAKE_COLUMN_DESC *) SF_CALLOC(1, sizeof(SNOWFLAKE_COLUMN_DESC));
+        desc[i] = (SF_COLUMN_DESC *) SF_CALLOC(1, sizeof(SF_COLUMN_DESC));
         if(json_copy_string(&desc[i]->name, column, "name")) {
             desc[i]->name = NULL;
         }

--- a/libsnowflakeclient/lib/results.h
+++ b/libsnowflakeclient/lib/results.h
@@ -17,12 +17,12 @@ extern "C" {
 
 #include <snowflake_client.h>
 
-SNOWFLAKE_TYPE string_to_snowflake_type(const char *string);
-SNOWFLAKE_C_TYPE snowflake_to_c_type(SNOWFLAKE_TYPE type, int64 precision, int64 scale);
-const char *snowflake_type_to_string(SNOWFLAKE_TYPE type);
-SNOWFLAKE_TYPE c_type_to_snowflake(SNOWFLAKE_C_TYPE c_type, SNOWFLAKE_TYPE tsmode);
-char *value_to_string(void *value, SNOWFLAKE_C_TYPE c_type);
-SNOWFLAKE_COLUMN_DESC ** set_description(const cJSON *rowtype);
+SF_TYPE string_to_snowflake_type(const char *string);
+SF_C_TYPE snowflake_to_c_type(SF_TYPE type, int64 precision, int64 scale);
+const char *snowflake_type_to_string(SF_TYPE type);
+SF_TYPE c_type_to_snowflake(SF_C_TYPE c_type, SF_TYPE tsmode);
+char *value_to_string(void *value, SF_C_TYPE c_type);
+SF_COLUMN_DESC ** set_description(const cJSON *rowtype);
 
 #ifdef __cplusplus
 }

--- a/libsnowflakeclient/lib/snowflake_client.c
+++ b/libsnowflakeclient/lib/snowflake_client.c
@@ -132,8 +132,8 @@ void STDCALL log_term() {
     }
 }
 
-SNOWFLAKE_STATUS STDCALL snowflake_global_init(const char *log_path) {
-    SNOWFLAKE_STATUS ret = SF_STATUS_ERROR;
+SF_STATUS STDCALL snowflake_global_init(const char *log_path) {
+    SF_STATUS ret = SF_STATUS_ERROR;
     CURLcode curl_ret;
 
     // Initialize constants
@@ -159,7 +159,7 @@ cleanup:
     return ret;
 }
 
-SNOWFLAKE_STATUS STDCALL snowflake_global_term() {
+SF_STATUS STDCALL snowflake_global_term() {
     log_term();
     curl_global_cleanup();
 
@@ -170,7 +170,7 @@ SNOWFLAKE_STATUS STDCALL snowflake_global_term() {
     return SF_STATUS_SUCCESS;
 }
 
-SNOWFLAKE_STATUS STDCALL snowflake_global_set_attribute(SNOWFLAKE_GLOBAL_ATTRIBUTE type, const void *value) {
+SF_STATUS STDCALL snowflake_global_set_attribute(SF_GLOBAL_ATTRIBUTE type, const void *value) {
     switch (type) {
         case SF_GLOBAL_DISABLE_VERIFY_PEER:
             DISABLE_VERIFY_PEER = *(sf_bool *) value;
@@ -196,8 +196,8 @@ SNOWFLAKE_STATUS STDCALL snowflake_global_set_attribute(SNOWFLAKE_GLOBAL_ATTRIBU
     }
 }
 
-SNOWFLAKE *STDCALL snowflake_init() {
-    SNOWFLAKE *sf = (SNOWFLAKE *) SF_CALLOC(1, sizeof(SNOWFLAKE));
+SF_CONNECT *STDCALL snowflake_init() {
+    SF_CONNECT *sf = (SF_CONNECT *) SF_CALLOC(1, sizeof(SF_CONNECT));
 
     // Make sure memory was actually allocated
     if (sf) {
@@ -228,7 +228,7 @@ SNOWFLAKE *STDCALL snowflake_init() {
     return sf;
 }
 
-void STDCALL snowflake_term(SNOWFLAKE *sf) {
+void STDCALL snowflake_term(SF_CONNECT *sf) {
     // Ensure object is not null
     if (sf) {
         SF_FREE(sf->host);
@@ -248,7 +248,7 @@ void STDCALL snowflake_term(SNOWFLAKE *sf) {
     SF_FREE(sf);
 }
 
-SNOWFLAKE_STATUS STDCALL snowflake_connect(SNOWFLAKE *sf) {
+SF_STATUS STDCALL snowflake_connect(SF_CONNECT *sf) {
     if (!sf) {
         return SF_STATUS_ERROR;
     }
@@ -267,7 +267,7 @@ SNOWFLAKE_STATUS STDCALL snowflake_connect(SNOWFLAKE *sf) {
             {"&warehouse=", sf->warehouse, NULL, NULL, 0, 0},
             {"&roleName=", sf->role, NULL, NULL, 0, 0},
     };
-    SNOWFLAKE_STATUS ret = SF_STATUS_ERROR;
+    SF_STATUS ret = SF_STATUS_ERROR;
 
     if(is_string_empty(sf->user) || is_string_empty(sf->account)) {
         // Invalid connection
@@ -325,7 +325,7 @@ cleanup:
     return ret;
 }
 
-SNOWFLAKE_STATUS STDCALL snowflake_close(SNOWFLAKE *sf) {
+SF_STATUS STDCALL snowflake_close(SF_CONNECT *sf) {
     if (!sf) {
         return SF_STATUS_ERROR;
     }
@@ -333,8 +333,8 @@ SNOWFLAKE_STATUS STDCALL snowflake_close(SNOWFLAKE *sf) {
     return SF_STATUS_SUCCESS;
 }
 
-SNOWFLAKE_STATUS STDCALL snowflake_set_attr(
-        SNOWFLAKE *sf, SNOWFLAKE_ATTRIBUTE type, const void *value) {
+SF_STATUS STDCALL snowflake_set_attr(
+        SF_CONNECT *sf, SF_ATTRIBUTE type, const void *value) {
     if (!sf) {
         return SF_STATUS_ERROR;
     }
@@ -404,8 +404,8 @@ SNOWFLAKE_STATUS STDCALL snowflake_set_attr(
     return SF_STATUS_SUCCESS;
 }
 
-SNOWFLAKE_STATUS STDCALL snowflake_get_attr(
-        SNOWFLAKE *sf, SNOWFLAKE_ATTRIBUTE type, void **value) {
+SF_STATUS STDCALL snowflake_get_attr(
+        SF_CONNECT *sf, SF_ATTRIBUTE type, void **value) {
     if (!sf) {
         return SF_STATUS_ERROR;
     }
@@ -419,7 +419,7 @@ SNOWFLAKE_STATUS STDCALL snowflake_get_attr(
  * @param sfstmt
  * @param free free allocated memory if true
  */
-static void STDCALL _snowflake_stmt_reset(SNOWFLAKE_STMT *sfstmt) {
+static void STDCALL _snowflake_stmt_reset(SF_STMT *sfstmt) {
     int64 i;
     clear_snowflake_error(&sfstmt->error);
 
@@ -467,12 +467,12 @@ static void STDCALL _snowflake_stmt_reset(SNOWFLAKE_STMT *sfstmt) {
     sfstmt->total_row_index = -1;
 }
 
-SNOWFLAKE_STMT *STDCALL snowflake_stmt(SNOWFLAKE *sf) {
+SF_STMT *STDCALL snowflake_stmt(SF_CONNECT *sf) {
     if (!sf) {
         return NULL;
     }
 
-    SNOWFLAKE_STMT *sfstmt = (SNOWFLAKE_STMT *) SF_CALLOC(1, sizeof(SNOWFLAKE_STMT));
+    SF_STMT *sfstmt = (SF_STMT *) SF_CALLOC(1, sizeof(SF_STMT));
     if (sfstmt) {
         _snowflake_stmt_reset(sfstmt);
         sfstmt->sequence_counter = ++sf->sequence_counter;
@@ -481,15 +481,15 @@ SNOWFLAKE_STMT *STDCALL snowflake_stmt(SNOWFLAKE *sf) {
     return sfstmt;
 }
 
-void STDCALL snowflake_stmt_close(SNOWFLAKE_STMT *sfstmt) {
+void STDCALL snowflake_stmt_close(SF_STMT *sfstmt) {
     if (sfstmt) {
         _snowflake_stmt_reset(sfstmt);
         SF_FREE(sfstmt);
     }
 }
 
-SNOWFLAKE_STATUS STDCALL snowflake_bind_param(
-    SNOWFLAKE_STMT *sfstmt, SNOWFLAKE_BIND_INPUT *sfbind) {
+SF_STATUS STDCALL snowflake_bind_param(
+    SF_STMT *sfstmt, SF_BIND_INPUT *sfbind) {
     if (!sfstmt) {
         return SF_STATUS_ERROR;
     }
@@ -501,8 +501,8 @@ SNOWFLAKE_STATUS STDCALL snowflake_bind_param(
     return SF_STATUS_SUCCESS;
 }
 
-SNOWFLAKE_STATUS STDCALL snowflake_bind_result(
-    SNOWFLAKE_STMT *sfstmt, SNOWFLAKE_BIND_OUTPUT *sfbind) {
+SF_STATUS STDCALL snowflake_bind_result(
+    SF_STMT *sfstmt, SF_BIND_OUTPUT *sfbind) {
     if (!sfstmt) {
         return SF_STATUS_ERROR;
     }
@@ -514,8 +514,8 @@ SNOWFLAKE_STATUS STDCALL snowflake_bind_result(
     return SF_STATUS_SUCCESS;
 }
 
-SNOWFLAKE_STATUS STDCALL snowflake_query(
-        SNOWFLAKE_STMT *sfstmt, const char *command) {
+SF_STATUS STDCALL snowflake_query(
+        SF_STMT *sfstmt, const char *command) {
     if (!sfstmt) {
         return SF_STATUS_ERROR;
     }
@@ -529,16 +529,16 @@ SNOWFLAKE_STATUS STDCALL snowflake_query(
     return SF_STATUS_SUCCESS;
 }
 
-SNOWFLAKE_STATUS STDCALL snowflake_fetch(SNOWFLAKE_STMT *sfstmt) {
+SF_STATUS STDCALL snowflake_fetch(SF_STMT *sfstmt) {
     if (!sfstmt) {
         return SF_STATUS_ERROR;
     }
     clear_snowflake_error(&sfstmt->error);
-    SNOWFLAKE_STATUS ret = SF_STATUS_ERROR;
+    SF_STATUS ret = SF_STATUS_ERROR;
     int64 i;
     cJSON *row = NULL;
     cJSON *raw_result;
-    SNOWFLAKE_BIND_OUTPUT *result;
+    SF_BIND_OUTPUT *result;
 
     // If no more results, set return to SF_STATUS_EOL
     if (cJSON_GetArraySize(sfstmt->raw_results) == 0) {
@@ -604,7 +604,7 @@ cleanup:
     return ret;
 }
 
-SNOWFLAKE_STATUS STDCALL snowflake_trans_begin(SNOWFLAKE *sf) {
+SF_STATUS STDCALL snowflake_trans_begin(SF_CONNECT *sf) {
     if (!sf) {
         return SF_STATUS_ERROR;
     }
@@ -612,7 +612,7 @@ SNOWFLAKE_STATUS STDCALL snowflake_trans_begin(SNOWFLAKE *sf) {
     return SF_STATUS_SUCCESS;
 }
 
-SNOWFLAKE_STATUS STDCALL snowflake_trans_commit(SNOWFLAKE *sf) {
+SF_STATUS STDCALL snowflake_trans_commit(SF_CONNECT *sf) {
     if (!sf) {
         return SF_STATUS_ERROR;
     }
@@ -620,7 +620,7 @@ SNOWFLAKE_STATUS STDCALL snowflake_trans_commit(SNOWFLAKE *sf) {
     return SF_STATUS_SUCCESS;
 }
 
-SNOWFLAKE_STATUS STDCALL snowflake_trans_rollback(SNOWFLAKE *sf) {
+SF_STATUS STDCALL snowflake_trans_rollback(SF_CONNECT *sf) {
     if (!sf) {
         return SF_STATUS_ERROR;
     }
@@ -628,19 +628,19 @@ SNOWFLAKE_STATUS STDCALL snowflake_trans_rollback(SNOWFLAKE *sf) {
     return SF_STATUS_SUCCESS;
 }
 
-int64 STDCALL snowflake_affected_rows(SNOWFLAKE_STMT *sfstmt) {
+int64 STDCALL snowflake_affected_rows(SF_STMT *sfstmt) {
     if (!sfstmt) {
         return -1;
     }
     return 0;
 }
 
-SNOWFLAKE_STATUS STDCALL snowflake_prepare(SNOWFLAKE_STMT *sfstmt, const char *command) {
+SF_STATUS STDCALL snowflake_prepare(SF_STMT *sfstmt, const char *command) {
     if (!sfstmt) {
         return SF_STATUS_ERROR;
     }
     clear_snowflake_error(&sfstmt->error);
-    SNOWFLAKE_STATUS ret = SF_STATUS_ERROR;
+    SF_STATUS ret = SF_STATUS_ERROR;
     size_t sql_text_size = 1; // Don't forget about null terminator
     if (!command) {
         goto cleanup;
@@ -657,13 +657,13 @@ cleanup:
     return ret;
 }
 
-SNOWFLAKE_STATUS STDCALL snowflake_execute(SNOWFLAKE_STMT *sfstmt) {
+SF_STATUS STDCALL snowflake_execute(SF_STMT *sfstmt) {
     if (!sfstmt) {
         return SF_STATUS_ERROR;
     }
     clear_snowflake_error(&sfstmt->error);
-    SNOWFLAKE_STATUS ret = SF_STATUS_ERROR;
-    SNOWFLAKE_JSON_ERROR json_error;
+    SF_STATUS ret = SF_STATUS_ERROR;
+    SF_JSON_ERROR json_error;
     const char *error_msg;
     cJSON *body = NULL;
     cJSON *data = NULL;
@@ -677,7 +677,7 @@ SNOWFLAKE_STATUS STDCALL snowflake_execute(SNOWFLAKE_STMT *sfstmt) {
     };
     size_t i;
     cJSON *bindings = NULL;
-    SNOWFLAKE_BIND_INPUT *input;
+    SF_BIND_INPUT *input;
     const char *type;
     char *value;
 
@@ -686,7 +686,7 @@ SNOWFLAKE_STATUS STDCALL snowflake_execute(SNOWFLAKE_STMT *sfstmt) {
         bindings = cJSON_CreateObject();
         for (i = 0; i < sfstmt->params->used; i++) {
             cJSON *binding;
-            input = (SNOWFLAKE_BIND_INPUT *) array_list_get(sfstmt->params, i + 1);
+            input = (SF_BIND_INPUT *) array_list_get(sfstmt->params, i + 1);
             // TODO check if input is null and either set error or write msg to log
             type = snowflake_type_to_string(c_type_to_snowflake(input->c_type, SF_TYPE_TIMESTAMP_NTZ));
             value = value_to_string(input->value, input->c_type);
@@ -727,7 +727,7 @@ SNOWFLAKE_STATUS STDCALL snowflake_execute(SNOWFLAKE_STMT *sfstmt) {
         if (json_copy_string_no_alloc(sfstmt->sqlstate, data, "sqlState", SQLSTATE_LEN)) {
             log_debug("No valid sqlstate found in response");
         }
-        if ((json_error = json_copy_bool(&success, resp, "success")) == SF_JSON_NO_ERROR && success) {
+        if ((json_error = json_copy_bool(&success, resp, "success")) == SF_JSON_ERROR_NONE && success) {
             // Set Database info
             if (json_copy_string(&sfstmt->connection->database, data, "finalDatabaseName")) {
                 log_warn("No valid database found in response");
@@ -757,7 +757,7 @@ SNOWFLAKE_STATUS STDCALL snowflake_execute(SNOWFLAKE_STMT *sfstmt) {
                 log_warn("No total count found in response. Reverting to using array size of results");
                 sfstmt->total_rowcount = cJSON_GetArraySize(sfstmt->raw_results);
             }
-        } else if (json_error != SF_JSON_NO_ERROR) {
+        } else if (json_error != SF_JSON_ERROR_NONE) {
             JSON_ERROR_MSG(json_error, error_msg, "Success code");
             SET_SNOWFLAKE_ERROR(&sfstmt->error, SF_ERROR_BAD_JSON, error_msg, sfstmt->sfqid);
             goto cleanup;
@@ -781,21 +781,21 @@ cleanup:
     return ret;
 }
 
-SNOWFLAKE_ERROR *STDCALL snowflake_error(SNOWFLAKE *sf) {
+SF_ERROR *STDCALL snowflake_error(SF_CONNECT *sf) {
     if (!sf) {
         return NULL;
     }
     return &sf->error;
 }
 
-SNOWFLAKE_ERROR *STDCALL snowflake_stmt_error(SNOWFLAKE_STMT *sfstmt) {
+SF_ERROR *STDCALL snowflake_stmt_error(SF_STMT *sfstmt) {
     if (!sfstmt) {
         return NULL;
     }
     return &sfstmt->error;
 }
 
-uint64 STDCALL snowflake_num_rows(SNOWFLAKE_STMT *sfstmt) {
+uint64 STDCALL snowflake_num_rows(SF_STMT *sfstmt) {
     // TODO fix int vs uint stuff
     if (!sfstmt) {
         // TODO change to -1?
@@ -804,7 +804,7 @@ uint64 STDCALL snowflake_num_rows(SNOWFLAKE_STMT *sfstmt) {
     return (uint64)sfstmt->total_rowcount;
 }
 
-uint64 STDCALL snowflake_num_fields(SNOWFLAKE_STMT *sfstmt) {
+uint64 STDCALL snowflake_num_fields(SF_STMT *sfstmt) {
     // TODO fix int vs uint stuff
     if (!sfstmt) {
         // TODO change to -1?
@@ -813,7 +813,7 @@ uint64 STDCALL snowflake_num_fields(SNOWFLAKE_STMT *sfstmt) {
     return (uint64)sfstmt->total_fieldcount;
 }
 
-uint64 STDCALL snowflake_param_count(SNOWFLAKE_STMT *sfstmt) {
+uint64 STDCALL snowflake_param_count(SF_STMT *sfstmt) {
     if (!sfstmt) {
         // TODO change to -1?
         return 0;
@@ -821,36 +821,36 @@ uint64 STDCALL snowflake_param_count(SNOWFLAKE_STMT *sfstmt) {
     return sfstmt->params->used;
 }
 
-const char *STDCALL snowflake_sfqid(SNOWFLAKE_STMT *sfstmt) {
+const char *STDCALL snowflake_sfqid(SF_STMT *sfstmt) {
     if (!sfstmt) {
         return NULL;
     }
     return sfstmt->sfqid;
 }
 
-const char *STDCALL snowflake_sqlstate(SNOWFLAKE_STMT *sfstmt) {
+const char *STDCALL snowflake_sqlstate(SF_STMT *sfstmt) {
     if (!sfstmt) {
         return NULL;
     }
     return sfstmt->sqlstate;
 }
 
-SNOWFLAKE_STATUS STDCALL snowflake_stmt_get_attr(
-  SNOWFLAKE_STMT *sfstmt, SNOWFLAKE_STMT_ATTRIBUTE type, void *value) {
+SF_STATUS STDCALL snowflake_stmt_get_attr(
+  SF_STMT *sfstmt, SF_STMT_ATTRIBUTE type, void *value) {
     if (!sfstmt) {
         return SF_STATUS_ERROR;
     }
-    // TODO: get the value from SNOWFLAKE_STMT.
+    // TODO: get the value from SF_STMT.
     return SF_STATUS_SUCCESS;
 }
 
-SNOWFLAKE_STATUS STDCALL snowflake_stmt_set_attr(
-  SNOWFLAKE_STMT *sfstmt, SNOWFLAKE_STMT_ATTRIBUTE type, const void *value) {
+SF_STATUS STDCALL snowflake_stmt_set_attr(
+  SF_STMT *sfstmt, SF_STMT_ATTRIBUTE type, const void *value) {
     if (!sfstmt) {
         return SF_STATUS_ERROR;
     }
     clear_snowflake_error(&sfstmt->error);
-    /* TODO: need extra member in SNOWFLAKE_STMT */
+    /* TODO: need extra member in SF_STMT */
     return SF_STATUS_SUCCESS;
 }
 

--- a/php_pdo_snowflake_int.h
+++ b/php_pdo_snowflake_int.h
@@ -43,16 +43,16 @@ typedef long zend_long;
 #endif /* PHP_VERSION_ID */
 
 typedef struct {
-    SNOWFLAKE *server;
+    SF_CONNECT *server;
 } pdo_snowflake_db_handle;
 
 typedef struct {
     pdo_snowflake_db_handle *H;
-    SNOWFLAKE_STMT *stmt;
+    SF_STMT *stmt;
 
     int64 num_params;
-    SNOWFLAKE_BIND_INPUT *bound_params;
-    SNOWFLAKE_BIND_OUTPUT *bound_result;
+    SF_BIND_INPUT *bound_params;
+    SF_BIND_OUTPUT *bound_result;
     sf_bool *out_null; /* TODO: need this? */
     zend_ulong *out_length; /* TODO: need this? */
 } pdo_snowflake_stmt;

--- a/snowflake_driver.c
+++ b/snowflake_driver.c
@@ -12,7 +12,7 @@ int _pdo_snowflake_error(pdo_dbh_t *dbh, pdo_stmt_t *stmt, const char *file,
 {
     pdo_snowflake_db_handle *H = (pdo_snowflake_db_handle *) dbh->driver_data;
     pdo_error_type *pdo_err;
-    SNOWFLAKE_ERROR *einfo;
+    SF_ERROR *einfo;
     pdo_snowflake_stmt *S = NULL;
 
     PDO_DBG_ENTER("_pdo_snowflake_error");
@@ -71,7 +71,7 @@ static int pdo_snowflake_fetch_error_func(
   pdo_dbh_t *dbh, pdo_stmt_t *stmt, zval *info) /* {{{ */
 {
     pdo_snowflake_db_handle *H = (pdo_snowflake_db_handle *) dbh->driver_data;
-    SNOWFLAKE_ERROR *einfo = NULL;
+    SF_ERROR *einfo = NULL;
 
     PDO_DBG_ENTER("pdo_snowflake_fetch_error_func");
     PDO_DBG_INF("dbh=%p stmt=%p", dbh, stmt);
@@ -202,7 +202,7 @@ snowflake_handle_doer(pdo_dbh_t *dbh, const char *sql, size_t sql_len) /* {{{ */
     // TODO add debugging statements
 
     PDO_DBG_INF("sql: %s, len: %d", sql, sql_len);
-    SNOWFLAKE_STMT *sfstmt = snowflake_stmt(H->server);
+    SF_STMT *sfstmt = snowflake_stmt(H->server);
     if (snowflake_query(sfstmt, sql) == SF_STATUS_SUCCESS) {
         PDO_DBG_INF("success");
         int64 rows = snowflake_affected_rows(sfstmt);

--- a/snowflake_stmt.c
+++ b/snowflake_stmt.c
@@ -60,7 +60,7 @@ static int pdo_snowflake_stmt_execute_prepared(pdo_stmt_t *stmt) /* {{{ */
 
     // TODO: bind parameters
     S->bound_params = NULL;
-    // ecalloc((size_t)S->num_params, sizeof(SNOWFLAKE_BIND_INPUT));
+    // ecalloc((size_t)S->num_params, sizeof(SF_BIND_INPUT));
 
     /* execute */
     if (snowflake_execute(S->stmt) != SF_STATUS_SUCCESS) {
@@ -72,10 +72,10 @@ static int pdo_snowflake_stmt_execute_prepared(pdo_stmt_t *stmt) /* {{{ */
     stmt->column_count = (int) snowflake_num_fields(S->stmt);
     PDO_DBG_INF("number of columns: %d", stmt->column_count);
     S->bound_result = ecalloc((size_t) stmt->column_count,
-                              sizeof(SNOWFLAKE_BIND_OUTPUT));
+                              sizeof(SF_BIND_OUTPUT));
     for (i = 0; i < stmt->column_count; ++i) {
         size_t len = 0;
-        SNOWFLAKE_COLUMN_DESC *desc = S->stmt->desc[i];
+        SF_COLUMN_DESC *desc = S->stmt->desc[i];
         S->bound_result[i].idx = (size_t) i + 1;  /* 1 based index */
         S->bound_result[i].type = SF_C_TYPE_STRING; /* string type */
         PDO_DBG_INF("prec: %d, scale: %d, name: %s, type: %d",
@@ -155,7 +155,7 @@ static int pdo_snowflake_stmt_fetch(
     if (ori != PDO_FETCH_ORI_NEXT) {
 
     }
-    SNOWFLAKE_STATUS ret = snowflake_fetch(S->stmt);
+    SF_STATUS ret = snowflake_fetch(S->stmt);
     if (ret == SF_STATUS_EOL) {
         PDO_DBG_INF("EOL");
         PDO_DBG_RETURN(0);


### PR DESCRIPTION
Refactored typedefs to use SF_ instead of SNOWFLAKE_ consistently throughout the whole library. Changed SF_NO_ERROR and SF_JSON_NO_ERROR to SF_ERROR_NONE and SF_JSON_ERROR_NONE respectively to make enum error naming more consistent. Change was made using IDE so all references were changed. Fixes #26