### PR TITLE
Added snowflake_desc and tests for both C and PHP

### DIFF
--- a/libsnowflakeclient/examples/crud.c
+++ b/libsnowflakeclient/examples/crud.c
@@ -45,6 +45,30 @@ int fetch_data(SF_STMT *stmt, int64 expected_sum) {
         goto exit;
     }
 
+    uint64 num_fields = snowflake_num_fields(stmt);
+    SF_COLUMN_DESC **descs = snowflake_desc(stmt);
+
+    if (num_fields != 2) {
+        fprintf(stderr,
+                "failed to get the number of fields. expected: 2, got: %llu",
+                num_fields);
+        goto exit;
+    }
+
+    int i;
+    for (i = 0; i < num_fields; ++i) {
+        printf(
+          "name: %s, type: %d, C type: %d, byte_size: %lld, "
+            "internal_size: %lld, precision: %lld, scale: %lld, null ok: %d\n",
+          descs[i]->name,
+          descs[i]->type,
+          descs[i]->c_type,
+          descs[i]->byte_size,
+          descs[i]->internal_size,
+          descs[i]->precision,
+          descs[i]->scale,
+          descs[i]->null_ok);
+    }
     int64 total = 0;
     while ((status = snowflake_fetch(stmt)) == SF_STATUS_SUCCESS) {
         printf("c1: %d, c2: %s\n", c1v, c2v);
@@ -89,7 +113,7 @@ int main() {
      * it is taken as a float */
     status = snowflake_query(
       stmt,
-      "create or replace table t (c1 number(10,0), c2 string)",
+      "create or replace table t (c1 number(10,0) not null, c2 string)",
       0
     );
     if (status != SF_STATUS_SUCCESS) {

--- a/libsnowflakeclient/include/snowflake_client.h
+++ b/libsnowflakeclient/include/snowflake_client.h
@@ -435,6 +435,14 @@ uint64 STDCALL snowflake_num_fields(SF_STMT *sfstmt);
 const char *STDCALL snowflake_sqlstate(SF_STMT *sfstmt);
 
 /**
+ * Gets an array of column metadata.
+ *
+ * @param sf SNOWFLAKE_STMT context.
+ * @return SF_COLUMN_DESC if success or NULL
+ */
+SF_COLUMN_DESC** STDCALL snowflake_desc(SF_STMT *sfstmt);
+
+/**
  * Prepares a statement.
  *
  * @param sfstmt SNOWFLAKE_STMT context.
@@ -486,7 +494,7 @@ SF_STATUS STDCALL snowflake_fetch(SF_STMT *sfstmt);
  * @param sfstmt SNOWFLAKE_STMT context.
  * @return the number of binding parameters in the statement.
  */
-uint64 STDCALL snowflake_param_count(SF_STMT *sfstmt);
+uint64 STDCALL snowflake_num_params(SF_STMT *sfstmt);
 
 /**
  * Binds parameters with the statement for execution.
@@ -517,6 +525,12 @@ SF_STATUS STDCALL snowflake_bind_result(
  */
 const char *STDCALL snowflake_sfqid(SF_STMT *sfstmt);
 
+/**
+ * Converts Snowflake Type enum value to a string representation
+ * @param type SF_TYPE enum
+ * @return a String representation of Snowflake Type
+ */
+const char *snowflake_type_to_string(SF_TYPE type);
 
 #ifdef  __cplusplus
 }

--- a/libsnowflakeclient/lib/results.h
+++ b/libsnowflakeclient/lib/results.h
@@ -19,7 +19,6 @@ extern "C" {
 
 SF_TYPE string_to_snowflake_type(const char *string);
 SF_C_TYPE snowflake_to_c_type(SF_TYPE type, int64 precision, int64 scale);
-const char *snowflake_type_to_string(SF_TYPE type);
 SF_TYPE c_type_to_snowflake(SF_C_TYPE c_type, SF_TYPE tsmode);
 char *value_to_string(void *value, size_t len, SF_C_TYPE c_type);
 SF_COLUMN_DESC ** set_description(const cJSON *rowtype);

--- a/libsnowflakeclient/lib/snowflake_client.c
+++ b/libsnowflakeclient/lib/snowflake_client.c
@@ -1045,7 +1045,7 @@ uint64 STDCALL snowflake_num_fields(SF_STMT *sfstmt) {
     return (uint64)sfstmt->total_fieldcount;
 }
 
-uint64 STDCALL snowflake_param_count(SF_STMT *sfstmt) {
+uint64 STDCALL snowflake_num_params(SF_STMT *sfstmt) {
     if (!sfstmt) {
         // TODO change to -1?
         return 0;
@@ -1065,6 +1065,13 @@ const char *STDCALL snowflake_sqlstate(SF_STMT *sfstmt) {
         return NULL;
     }
     return sfstmt->error.sqlstate;
+}
+
+SF_COLUMN_DESC** STDCALL snowflake_desc(SF_STMT *sfstmt) {
+    if (!sfstmt) {
+        return NULL;
+    }
+    return sfstmt->desc;
 }
 
 SF_STATUS STDCALL snowflake_stmt_get_attr(

--- a/snowflake_driver.c
+++ b/snowflake_driver.c
@@ -484,7 +484,7 @@ pdo_snowflake_handle_factory(pdo_dbh_t *dbh, zval *driver_options) /* {{{ */
         }
 
         /* autocommit */
-        dbh->auto_commit = (unsigned)auto_commit;
+        dbh->auto_commit = (unsigned) auto_commit;
     }
 
     // Set context attributes

--- a/tests/crud.phpt
+++ b/tests/crud.phpt
@@ -81,6 +81,16 @@ pdo_snowflake.cacert=libsnowflakeclient/cacert.pem
         echo "inserted rows: " . $sth->rowCount() . "\n";
 
         $sth = $dbh->query("select * from t order by 1");
+        $meta = $sth->getColumnMeta(0);
+        echo sprintf(
+            "name: %s, native_type: %s, len: %d, precision: %d, scale: %d\n",
+             $meta["name"], $meta["native_type"], $meta["len"],
+              $meta["precision"], $meta["scale"]);
+        $meta = $sth->getColumnMeta(1);
+        echo sprintf(
+            "name: %s, native_type: %s, len: %d, precision: %d, scale: %d\n",
+             $meta["name"], $meta["native_type"], $meta["len"],
+              $meta["precision"], $meta["scale"]);
         while($row = $sth->fetch()) {
             echo $row["C1"] . " " . $row["C2"] . "\n";
         }
@@ -108,6 +118,8 @@ deleted rows: 1
 3 test101
 inserted rows: 1
 inserted rows: 1
+name: C1, native_type: FIXED, len: 0, precision: 38, scale: 0
+name: C2, native_type: TEXT, len: 16777216, precision: 0, scale: 0
 1 test1
 3 test101
 11 test111


### PR DESCRIPTION
- Added `snowflake_desc` to get the column metadata from stmt
- Change the function name `snowflake_param_count` to `snowflake_num_params` to be consistent with other `snowflake_num_*` function names.
- Implemented PDO statement column metadata callback