### PR TITLE
added VARIANT, ARRAY and OBJECT binding and fetching support in PHP

### DIFF
--- a/libsnowflakeclient/examples/CMakeLists.txt
+++ b/libsnowflakeclient/examples/CMakeLists.txt
@@ -14,7 +14,8 @@ SET(EXAMPLES
         stmt_with_bad_connect
         crud
         error_handling
-        large_result_set)
+        large_result_set
+        selectvar)
 
 set(SOURCE_UTILS
         example_setup.c)

--- a/libsnowflakeclient/examples/crud.c
+++ b/libsnowflakeclient/examples/crud.c
@@ -25,7 +25,7 @@ int fetch_data(SF_STMT *stmt, int64 expected_sum) {
     SF_BIND_OUTPUT c1;
     c1.idx = 1;
     c1.max_length = sizeof(c1v);
-    c1.type = SF_C_TYPE_INT64;
+    c1.c_type = SF_C_TYPE_INT64;
     c1.value = &c1v;
     status = snowflake_bind_result(stmt, &c1);
     if (status != SF_STATUS_SUCCESS) {
@@ -37,7 +37,7 @@ int fetch_data(SF_STMT *stmt, int64 expected_sum) {
     SF_BIND_OUTPUT c2;
     c2.idx = 2;
     c2.max_length = sizeof(c2v);
-    c2.type = SF_C_TYPE_STRING;
+    c2.c_type = SF_C_TYPE_STRING;
     c2.value = &c2v;
     status = snowflake_bind_result(stmt, &c2);
     if (status != SF_STATUS_SUCCESS) {

--- a/libsnowflakeclient/examples/large_result_set.c
+++ b/libsnowflakeclient/examples/large_result_set.c
@@ -36,7 +36,7 @@ int main() {
     int64 out = 0;
     uint64 counter = 0;
     c1.idx = 1;
-    c1.type = SF_C_TYPE_INT64;
+    c1.c_type = SF_C_TYPE_INT64;
     c1.value = (void *) &out;
     c1.len = sizeof(out);
     snowflake_bind_result(sfstmt, &c1);

--- a/libsnowflakeclient/examples/select1.c
+++ b/libsnowflakeclient/examples/select1.c
@@ -4,7 +4,6 @@
 
 
 #include <stdio.h>
-#include <stdlib.h>
 #include <snowflake_client.h>
 #include <example_setup.h>
 
@@ -28,7 +27,7 @@ int main() {
     SF_BIND_OUTPUT c1;
     int64 out = 0;
     c1.idx = 1;
-    c1.type = SF_C_TYPE_INT64;
+    c1.c_type = SF_C_TYPE_INT64;
     c1.value = (void *) &out;
     c1.len = sizeof(out);
     snowflake_bind_result(sfstmt, &c1);

--- a/libsnowflakeclient/examples/selectvar.c
+++ b/libsnowflakeclient/examples/selectvar.c
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2017 Snowflake Computing, Inc. All rights reserved.
+ */
+
+
+#include <stdio.h>
+#include <snowflake_client.h>
+#include <example_setup.h>
+#include <memory.h>
+
+
+int main() {
+    /* init */
+    SF_STATUS status;
+    initialize_snowflake_example(SF_BOOLEAN_FALSE);
+    SF_CONNECT *sf = setup_snowflake_connection();
+
+    status = snowflake_connect(sf);
+    if (status != SF_STATUS_SUCCESS) {
+        fprintf(stderr, "Connecting to snowflake failed, exiting...\n");
+        SF_ERROR *error = snowflake_error(sf);
+        fprintf(stderr, "Error message: %s\nIn File, %s, Line, %d\n",
+                error->msg, error->file, error->line);
+        goto cleanup;
+    }
+
+    /* Create a statement once and reused */
+    SF_STMT *sfstmt = snowflake_stmt(sf);
+    /* NOTE: the numeric type here should fit into int64 otherwise
+     * it is taken as a float */
+    status = snowflake_query(
+      sfstmt,
+      "create or replace table t (c1 object, c2 array, c3 variant)",
+      0
+    );
+    if (status != SF_STATUS_SUCCESS) {
+        SF_ERROR *error = snowflake_error(sf);
+        fprintf(stderr, "Error message: %s\nIn File, %s, Line, %d\n",
+                error->msg, error->file, error->line);
+        goto cleanup;
+    }
+
+    /* insert data */
+    status = snowflake_prepare(sfstmt,
+                               "insert into t select parse_json(?),parse_json(?),parse_json(?)",
+                               0);
+    if (status != SF_STATUS_SUCCESS) {
+        SF_ERROR *error = snowflake_error(sf);
+        fprintf(stderr, "Error message: %s\nIn File, %s, Line, %d\n",
+                error->msg, error->file, error->line);
+        goto cleanup;
+    }
+
+    SF_BIND_INPUT ic1;
+    char ic1buf[1024];
+    strcpy(ic1buf, "{\"test1\":1}");
+    ic1.idx = 1;
+    ic1.c_type = SF_C_TYPE_STRING;
+    ic1.value = (void *) ic1buf;
+    ic1.len = strlen(ic1buf);
+    snowflake_bind_param(sfstmt, &ic1);
+
+    SF_BIND_INPUT ic2;
+    char ic2buf[1024];
+    strcpy(ic2buf, "'[1,2,3]'");
+    ic2.idx = 2;
+    ic2.c_type = SF_C_TYPE_STRING;
+    ic2.value = (void *) ic2buf;
+    ic2.len = strlen(ic2buf);
+    snowflake_bind_param(sfstmt, &ic2);
+
+    SF_BIND_INPUT ic3;
+    char ic3buf[1024];
+    strcpy(ic3buf, "'[456,789]'");
+    ic3.idx = 3;
+    ic3.c_type = SF_C_TYPE_STRING;
+    ic3.value = (void *) ic3buf;
+    ic3.len = strlen(ic3buf);
+    snowflake_bind_param(sfstmt, &ic3);
+
+    status = snowflake_execute(sfstmt);
+    if (status != SF_STATUS_SUCCESS) {
+        SF_ERROR *error = snowflake_error(sf);
+        fprintf(stderr, "Error message: %s\nIn File, %s, Line, %d\n",
+                error->msg, error->file, error->line);
+        goto cleanup;
+    }
+    printf("Inserted one row\n");
+
+    /* query */
+    status = snowflake_query(sfstmt, "select * from t", 0);
+    if (status != SF_STATUS_SUCCESS) {
+        SF_ERROR *error = snowflake_error(sf);
+        fprintf(stderr, "Error message: %s\nIn File, %s, Line, %d\n",
+                error->msg, error->file, error->line);
+        goto cleanup;
+    }
+
+    SF_BIND_OUTPUT c1;
+    char c1buf[1024];
+    c1.idx = 1;
+    c1.c_type = SF_C_TYPE_STRING;
+    c1.value = (void *) c1buf;
+    c1.len = sizeof(c1buf);
+    c1.max_length = sizeof(c1buf);
+    snowflake_bind_result(sfstmt, &c1);
+
+    SF_BIND_OUTPUT c2;
+    char c2buf[1024];
+    c2.idx = 2;
+    c2.c_type = SF_C_TYPE_STRING;
+    c2.value = (void *) c2buf;
+    c2.len = sizeof(c2buf);
+    c2.max_length = sizeof(c2buf);
+    snowflake_bind_result(sfstmt, &c2);
+
+    SF_BIND_OUTPUT c3;
+    char c3buf[1024];
+    c3.idx = 3;
+    c3.c_type = SF_C_TYPE_STRING;
+    c3.value = (void *) c3buf;
+    c3.max_length = sizeof(c3buf);
+    snowflake_bind_result(sfstmt, &c3);
+
+    printf("Number of rows: %d\n", (int) snowflake_num_rows(sfstmt));
+
+    while ((status = snowflake_fetch(sfstmt)) == SF_STATUS_SUCCESS) {
+        printf("result: %s, %s, %s\n", (char *) c1.value, (char *) c2.value,
+               (char *) c3.value);
+    }
+
+    // If we reached end of line, then we were successful
+    if (status == SF_STATUS_EOL) {
+        status = SF_STATUS_SUCCESS;
+    } else if (status == SF_STATUS_ERROR || status == SF_STATUS_WARNING) {
+        SF_ERROR *error = snowflake_stmt_error(sfstmt);
+        fprintf(stderr, "Error message: %s\nIn File, %s, Line, %d\n",
+                error->msg, error->file, error->line);
+    }
+
+cleanup:
+    /* delete statement */
+    snowflake_stmt_term(sfstmt);
+
+    /* close and term */
+    snowflake_term(sf); // purge snowflake context
+    snowflake_global_term();
+
+    return status;
+}

--- a/libsnowflakeclient/examples/stmt_with_bad_connect.c
+++ b/libsnowflakeclient/examples/stmt_with_bad_connect.c
@@ -21,7 +21,7 @@ int main() {
     SF_BIND_OUTPUT c1;
     int out = 0;
     c1.idx = 1;
-    c1.type = SF_C_TYPE_INT64;
+    c1.c_type = SF_C_TYPE_INT64;
     c1.value = (void *) &out;
     snowflake_bind_result(sfstmt, &c1);
     status = snowflake_execute(sfstmt);

--- a/libsnowflakeclient/examples/transaction.c
+++ b/libsnowflakeclient/examples/transaction.c
@@ -106,7 +106,7 @@ int main() {
     SF_BIND_OUTPUT v1;
 
     v1.idx = 1;
-    v1.type = SF_C_TYPE_INT64;
+    v1.c_type = SF_C_TYPE_INT64;
     v1.value = &v;
     v1.max_length = sizeof(v1);
     status = snowflake_bind_result(sfstmt, &v1);

--- a/libsnowflakeclient/include/snowflake_client.h
+++ b/libsnowflakeclient/include/snowflake_client.h
@@ -25,6 +25,11 @@ extern "C" {
 #define SQLSTATE_LEN 6
 
 /**
+ * The maximum object size
+ */
+#define SF_MAX_OBJECT_SIZE 16777216
+
+/**
  * Snowflake Data types
  */
 typedef enum sf_type {
@@ -248,7 +253,7 @@ typedef struct sf_snowflake_input
 typedef struct sf_snowflake_output
 {
     size_t idx; /* One based index of the columns */
-    SF_C_TYPE type; /* expected data type in C */
+    SF_C_TYPE c_type; /* expected data type in C */
     void *value; /* output value */
     size_t max_length; /* maximum buffer size provided by application */
     size_t len; /* actual value length */

--- a/libsnowflakeclient/lib/snowflake_client.c
+++ b/libsnowflakeclient/lib/snowflake_client.c
@@ -706,7 +706,7 @@ SF_STATUS STDCALL snowflake_fetch(SF_STMT *sfstmt) {
         if (result == NULL) {
             continue;
         } else {
-            if (result->type != sfstmt->desc[i]->c_type && result->type != SF_C_TYPE_STRING) {
+            if (result->c_type != sfstmt->desc[i]->c_type && result->c_type != SF_C_TYPE_STRING) {
                 // TODO add error msg
                 goto cleanup;
             }
@@ -725,26 +725,26 @@ SF_STATUS STDCALL snowflake_fetch(SF_STMT *sfstmt) {
         } else {
             raw_result = cJSON_GetArrayItem(row, i);
             // TODO turn into switch statement
-            if (result->type == SF_C_TYPE_INT8) {
+            if (result->c_type == SF_C_TYPE_INT8) {
                 if (sfstmt->desc[i]->type == SF_TYPE_BOOLEAN) {
                     *(int8 *) result->value = cJSON_IsTrue(raw_result) ? SF_BOOLEAN_TRUE : SF_BOOLEAN_FALSE;
                 } else {
                     // field is a char?
                     *(int8 *) result->value = (int8) raw_result->valuestring[0];
                 }
-            } else if (result->type == SF_C_TYPE_UINT8) {
+            } else if (result->c_type == SF_C_TYPE_UINT8) {
                 *(uint8 *) result->value = (uint8) raw_result->valuestring[0];
-            } else if (result->type == SF_C_TYPE_INT64) {
+            } else if (result->c_type == SF_C_TYPE_INT64) {
                 *(int64 *) result->value = (int64) strtoll(raw_result->valuestring, NULL, 10);
-            } else if (result->type == SF_C_TYPE_UINT64) {
+            } else if (result->c_type == SF_C_TYPE_UINT64) {
                 *(uint64 *) result->value = (uint64) strtoull(raw_result->valuestring, NULL, 10);
-            } else if (result->type == SF_C_TYPE_FLOAT64) {
+            } else if (result->c_type == SF_C_TYPE_FLOAT64) {
                 *(float64 *) result->value = (float64) strtod(raw_result->valuestring, NULL);
-            } else if (result->type == SF_C_TYPE_STRING) {
+            } else if (result->c_type == SF_C_TYPE_STRING) {
                 /* copy original data as is except Date/Time/Timestamp/Binary type */
                 strncpy(result->value, raw_result->valuestring, result->max_length);
                 result->len = strlen(raw_result->valuestring); /* TODO: what if null is included? */
-            } else if (result->type == SF_C_TYPE_TIMESTAMP) {
+            } else if (result->c_type == SF_C_TYPE_TIMESTAMP) {
                 // TODO Do some timestamp stuff here
             } else {
                 // TODO Create default case

--- a/tests/select1.phpt
+++ b/tests/select1.phpt
@@ -1,5 +1,5 @@
 --TEST--
-pdo_snowflake - select1
+pdo_snowflake - select 1
 --INI--
 pdo_snowflake.cacert=libsnowflakeclient/cacert.pem
 --FILE--

--- a/tests/selectvar.phpt
+++ b/tests/selectvar.phpt
@@ -1,0 +1,105 @@
+--TEST--
+pdo_snowflake - select var
+--INI--
+pdo_snowflake.cacert=libsnowflakeclient/cacert.pem
+--FILE--
+<?php
+    include __DIR__ . "/common.php";
+    try {
+        $dbh = new PDO($dsn, $user, $password);
+        $dbh->setAttribute( PDO::ATTR_ERRMODE, PDO::ERRMODE_WARNING );
+        echo "Connected to Snowflake\n";
+
+        $count = $dbh->exec("create or replace table t (c1 object, c2 array, c3 variant)");
+        if ($count == 0) {
+            print_r($dbh->errorInfo());
+        }
+        $sth = $dbh->prepare("insert into t select parse_json(?),parse_json(?),parse_json(?)");
+        $v1 = "{\"test1\":1}";
+        $sth->bindParam(1, $v1);
+        $v2 = "[1,2,3]";
+        $sth->bindParam(2, $v2);
+        $v3 = "[456,789]";
+        $sth->bindParam(3, $v3);
+        $sth->execute();
+        $sth = $dbh->query("select * from t order by 1");
+        $meta = $sth->getColumnMeta(0);
+        print_r($meta);
+        $meta = $sth->getColumnMeta(1);
+        print_r($meta);
+        $meta = $sth->getColumnMeta(2);
+        print_r($meta);
+        while($row = $sth->fetch()) {
+            print_r(json_decode($row["C1"], true));
+            print_r(json_decode($row["C2"], true));
+            print_r(json_decode($row["C3"], true));
+        }
+        
+        $count = $dbh->exec("drop table if exists t");
+
+    } catch(Exception $e) {
+        print_r($e);
+        echo "dsn is: $dsn\n";
+        echo "user is: $user\n";
+    }
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+Connected to Snowflake
+Array
+(
+    [scale] => 0
+    [native_type] => OBJECT
+    [flags] => Array
+        (
+        )
+
+    [name] => C1
+    [len] => 16777216
+    [precision] => 0
+    [pdo_type] => 2
+)
+Array
+(
+    [scale] => 0
+    [native_type] => ARRAY
+    [flags] => Array
+        (
+        )
+
+    [name] => C2
+    [len] => 16777216
+    [precision] => 0
+    [pdo_type] => 2
+)
+Array
+(
+    [scale] => 0
+    [native_type] => VARIANT
+    [flags] => Array
+        (
+        )
+
+    [name] => C3
+    [len] => 16777216
+    [precision] => 0
+    [pdo_type] => 2
+)
+Array
+(
+    [test1] => 1
+)
+Array
+(
+    [0] => 1
+    [1] => 2
+    [2] => 3
+)
+Array
+(
+    [0] => 456
+    [1] => 789
+)
+===DONE===
+


### PR DESCRIPTION
- Changed SF_BIND_OUTPUT.type to SF_BIND_OUTPUT.c_type to be consistent with SF_BIND_INPUT. I believe SF_BIND_INPUT requires `type` member anyway to specify Snowflake data type
- Fixed VARIANT, ARRAY and OBJECT binding and fetching support in PHP. No data size is given from the server, so it assumes the max length when fetching data.