### PR TITLE
Fetch Performance Improvements, Part 1

### DIFF
--- a/libsnowflakeclient/include/snowflake_client.h
+++ b/libsnowflakeclient/include/snowflake_client.h
@@ -230,6 +230,7 @@ typedef struct sf_snowflake_statement {
     SF_CONNECT *connection;
     char *sql_text;
     void *raw_results;
+    int64 chunk_rowcount;
     int64 total_rowcount;
     int64 total_fieldcount;
     int64 total_row_index;


### PR DESCRIPTION
Removed calls to cJSON_GetArraySize with a chunk_rowcount variable for each statement object that keeps track of the number of rows left in the chunk. When this reaches 0, we replace the chunk.