### PR TITLE
updated bool support. "1" for true and "" for false

### DIFF
--- a/libsnowflakeclient/include/snowflake_basic_types.h
+++ b/libsnowflakeclient/include/snowflake_basic_types.h
@@ -28,8 +28,20 @@ typedef int8 sf_bool;
 extern int8 SF_BOOLEAN_TRUE;
 extern int8 SF_BOOLEAN_FALSE;
 
-#define SF_BOOLEAN_TRUE_STR "TRUE"
-#define SF_BOOLEAN_FALSE_STR "FALSE"
+/**
+ * Boolean data type string representation for Snowflake
+ */
+#define SF_BOOLEAN_INT_TRUE_STR "TRUE"
+#define SF_BOOLEAN_INT_FALSE_STR "FALSE"
+
+/**
+ * Boolean data type string representation for results.
+ *
+ * This is mainly used by PHP PDO Snwoflake but should work fine
+ * for other cases.
+ */
+#define SF_BOOLEAN_TRUE_STR "1"
+#define SF_BOOLEAN_FALSE_STR ""
 
 #ifdef __cplusplus
 }

--- a/libsnowflakeclient/lib/connection.c
+++ b/libsnowflakeclient/lib/connection.c
@@ -138,7 +138,7 @@ cJSON *STDCALL create_auth_json_body(SF_CONNECT *sf,
     cJSON_AddStringToObject(
       session_parameters,
       "AUTOCOMMIT",
-      autocommit == SF_BOOLEAN_TRUE ? SF_BOOLEAN_TRUE_STR : SF_BOOLEAN_FALSE_STR);
+      autocommit == SF_BOOLEAN_TRUE ? SF_BOOLEAN_INT_TRUE_STR : SF_BOOLEAN_INT_FALSE_STR);
 
     //Create Request Data JSON blob
     data = cJSON_CreateObject();

--- a/libsnowflakeclient/lib/results.c
+++ b/libsnowflakeclient/lib/results.c
@@ -152,9 +152,9 @@ char *value_to_string(void *value, size_t len, SF_C_TYPE c_type) {
             snprintf(ret, size, "%f", *(float64 *) value);
             return ret;
         case SF_C_TYPE_BOOLEAN:
-            size = *(sf_bool*)value == SF_BOOLEAN_TRUE ? sizeof(SF_BOOLEAN_TRUE_STR) : sizeof(SF_BOOLEAN_FALSE_STR) + 1;
-            ret = (char*) SF_CALLOC(1, size);
-            strncpy(ret, *(sf_bool*)value == SF_BOOLEAN_TRUE ? SF_BOOLEAN_TRUE_STR : SF_BOOLEAN_FALSE_STR, size);
+            size = *(sf_bool*)value == SF_BOOLEAN_TRUE ? sizeof(SF_BOOLEAN_INT_TRUE_STR) : sizeof(SF_BOOLEAN_INT_FALSE_STR);
+            ret = (char*) SF_CALLOC(1, size + 1);
+            strncpy(ret, *(sf_bool*)value == SF_BOOLEAN_TRUE ? SF_BOOLEAN_INT_TRUE_STR : SF_BOOLEAN_INT_FALSE_STR, size + 1);
             return ret;
         case SF_C_TYPE_STRING:
             size = (size_t)len + 1;

--- a/snowflake_driver.c
+++ b/snowflake_driver.c
@@ -341,7 +341,7 @@ pdo_snowflake_set_attribute(pdo_dbh_t *dbh, zend_long attr, zval *val) /* {{{ */
                 dbh->auto_commit = bval;
                 PDO_DBG_INF(
                   "value=%s",
-                  bval ? SF_BOOLEAN_TRUE_STR : SF_BOOLEAN_FALSE_STR);
+                  bval ? SF_BOOLEAN_INT_TRUE_STR : SF_BOOLEAN_INT_FALSE_STR);
             }
             PDO_DBG_RETURN(1);
             break;

--- a/snowflake_stmt.c
+++ b/snowflake_stmt.c
@@ -157,7 +157,10 @@ static int pdo_snowflake_stmt_execute_prepared(pdo_stmt_t *stmt) /* {{{ */
             case SF_TYPE_BINARY:
                 break;
             case SF_TYPE_BOOLEAN:
-                len = sizeof(SF_BOOLEAN_FALSE_STR);
+                len =
+                  (sizeof(SF_BOOLEAN_TRUE_STR) > sizeof(SF_BOOLEAN_FALSE_STR)
+                   ? sizeof(SF_BOOLEAN_TRUE_STR)
+                   : sizeof(SF_BOOLEAN_FALSE_STR)) - 1;
                 break;
             case SF_TYPE_DATE:
                 break;
@@ -285,7 +288,7 @@ static int pdo_snowflake_stmt_describe(pdo_stmt_t *stmt, int colno) /* {{{ */
                 cols[i].maxlen = SF_MAX_OBJECT_SIZE;
                 break;
             case SF_TYPE_BOOLEAN:
-                cols[i].maxlen = sizeof(SF_BOOLEAN_FALSE_STR);
+                cols[i].maxlen = sizeof(SF_BOOLEAN_INT_FALSE_STR);
             case SF_TYPE_TIMESTAMP_TZ:
             case SF_TYPE_TIMESTAMP_NTZ:
             case SF_TYPE_TIMESTAMP_LTZ:
@@ -553,7 +556,7 @@ static int pdo_snowflake_stmt_col_meta(
     }
     add_assoc_long(return_value, "scale", (zend_long) F[colno]->scale);
     add_assoc_string(return_value, "native_type",
-                     (char*)snowflake_type_to_string(F[colno]->type));
+                     (char *) snowflake_type_to_string(F[colno]->type));
     add_assoc_zval(return_value, "flags", &flags);
 
     PDO_DBG_RETURN(0);

--- a/tests/selectbool.phpt
+++ b/tests/selectbool.phpt
@@ -38,7 +38,11 @@ pdo_snowflake.cacert=libsnowflakeclient/cacert.pem
             echo "Results in String\n";
         while($row = $sth->fetch()) {
             echo sprintf("C1: %s\n", $row[0]);
-            echo sprintf("C2: %s\n", $row[1]);
+            if ($row[1]) {
+                echo "C2: TRUE\n";
+            } else {
+                echo "C2: FALSE\n";
+            }
         }
         $count = $dbh->exec("drop table if exists t");
 


### PR DESCRIPTION
Fixed the boolean support for PHP.

The original implementation was return "TRUE" or "FALSE" for True and False string representation.
However, both are taken as True in PHP.

Although we could add PHP special case now, I changed the behavior for PHP, because no other driver has been requested on the top of C API. We may add a flag when we need different behavior later.