### PR TITLE
Get desc function

### DIFF
--- a/libsnowflakeclient/examples/CMakeLists.txt
+++ b/libsnowflakeclient/examples/CMakeLists.txt
@@ -18,7 +18,8 @@ SET(EXAMPLES
         selectvar
         selectnum
         selectbool
-        selectbin)
+        selectbin
+        check_ctypes)
 
 set(SOURCE_UTILS
         example_setup.c)

--- a/libsnowflakeclient/examples/check_ctypes.c
+++ b/libsnowflakeclient/examples/check_ctypes.c
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2017 Snowflake Computing, Inc. All rights reserved.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <snowflake_client.h>
+#include <example_setup.h>
+
+const char *c_type_to_string(SF_C_TYPE type) {
+    switch (type) {
+        case SF_C_TYPE_STRING:
+            return "SF_C_TYPE_STRING";
+        case SF_C_TYPE_UINT8:
+            return "SF_C_TYPE_UINT8";
+        case SF_C_TYPE_INT8:
+            return "SF_C_TYPE_INT8";
+        case SF_C_TYPE_UINT64:
+            return "SF_C_TYPE_UINT64";
+        case SF_C_TYPE_INT64:
+            return "SF_C_TYPE_INT64";
+        case SF_C_TYPE_FLOAT64:
+            return "SF_C_TYPE_FLOAT64";
+        case SF_C_TYPE_BOOLEAN:
+            return "SF_C_TYPE_BOOLEAN";
+        case SF_C_TYPE_TIMESTAMP:
+            return "SF_C_TYPE_TIMESTAMP";
+        default:
+            return "unknown";
+    }
+}
+
+int main() {
+    /* init */
+    SF_STATUS status;
+    SF_CONNECT *sf = NULL;
+    SF_STMT *sfstmt = NULL;
+    initialize_snowflake_example(SF_BOOLEAN_FALSE);
+    sf = setup_snowflake_connection();
+    status = snowflake_connect(sf);
+    if (status != SF_STATUS_SUCCESS) {
+        fprintf(stderr, "Connecting to snowflake failed, exiting...\n");
+        SF_ERROR *error = snowflake_error(sf);
+        fprintf(stderr, "Error message: %s\nIn File, %s, Line, %d\n", error->msg, error->file, error->line);
+        goto cleanup;
+    } else {
+        printf("Connected to Snowflake\n");
+    }
+
+    sfstmt = snowflake_stmt(sf);
+    status = snowflake_query(sfstmt, "select seq4(), randstr(1000,random()), as_double(10.01) from table(generator(rowcount=>1));", 0);
+    if (status != SF_STATUS_SUCCESS) {
+        SF_ERROR *error = snowflake_stmt_error(sfstmt);
+        fprintf(stderr, "Error message: %s\nIn File, %s, Line, %d\n", error->msg, error->file, error->line);
+        goto cleanup;
+    } else {
+        printf("Query executed successfully\n");
+    }
+    SF_COLUMN_DESC *desc = snowflake_desc(sfstmt);
+
+    // Check seq4 type
+    if (desc[0].c_type != SF_C_TYPE_INT64) {
+        fprintf(stderr, "Error, seq4 column is not type SF_C_TYPE_INT64. Actual type is %s\n", c_type_to_string(desc[0].c_type));
+        status = SF_STATUS_ERROR;
+    } else {
+        printf("INT64 type check succeeded\n");
+    }
+
+    // Check randstr type
+    if (desc[1].c_type != SF_C_TYPE_STRING) {
+        fprintf(stderr, "Error, randstr column is not type SF_C_TYPE_STRING. Actual type is %s\n", c_type_to_string(desc[1].c_type));
+        status = SF_STATUS_ERROR;
+    } else {
+        printf("STRING type check succeeded\n");
+    }
+
+    // Check as_double type
+    if (desc[2].c_type != SF_C_TYPE_FLOAT64) {
+        fprintf(stderr, "Error, as_double('10.01') column is not type SF_C_TYPE_FLOAT64. Actual type is %s\n", c_type_to_string(desc[2].c_type));
+        status = SF_STATUS_ERROR;
+    } else {
+        printf("FLOAT64 type check succeeded\n");
+    }
+
+cleanup:
+    snowflake_stmt_term(sfstmt);
+
+    /* close and term */
+    snowflake_term(sf); // purge snowflake context
+    snowflake_global_term();
+
+    return status;
+}

--- a/libsnowflakeclient/examples/crud.c
+++ b/libsnowflakeclient/examples/crud.c
@@ -46,7 +46,7 @@ int fetch_data(SF_STMT *stmt, int64 expected_sum) {
     }
 
     uint64 num_fields = snowflake_num_fields(stmt);
-    SF_COLUMN_DESC **descs = snowflake_desc(stmt);
+    SF_COLUMN_DESC *descs = snowflake_desc(stmt);
 
     if (num_fields != 2) {
         fprintf(stderr,
@@ -60,14 +60,14 @@ int fetch_data(SF_STMT *stmt, int64 expected_sum) {
         printf(
           "name: %s, type: %d, C type: %d, byte_size: %lld, "
             "internal_size: %lld, precision: %lld, scale: %lld, null ok: %d\n",
-          descs[i]->name,
-          descs[i]->type,
-          descs[i]->c_type,
-          descs[i]->byte_size,
-          descs[i]->internal_size,
-          descs[i]->precision,
-          descs[i]->scale,
-          descs[i]->null_ok);
+          descs[i].name,
+          descs[i].type,
+          descs[i].c_type,
+          descs[i].byte_size,
+          descs[i].internal_size,
+          descs[i].precision,
+          descs[i].scale,
+          descs[i].null_ok);
     }
     int64 total = 0;
     while ((status = snowflake_fetch(stmt)) == SF_STATUS_SUCCESS) {

--- a/libsnowflakeclient/include/snowflake_client.h
+++ b/libsnowflakeclient/include/snowflake_client.h
@@ -235,10 +235,9 @@ typedef struct sf_snowflake_statement {
     int64 total_rowcount;
     int64 total_fieldcount;
     int64 total_row_index;
-    // TODO Create Bind list
     void* params;
     void *results;
-    SF_COLUMN_DESC **desc;
+    SF_COLUMN_DESC *desc;
     void *stmt_attrs;
     sf_bool is_dml;
     SF_CHUNK_DOWNLOADER *chunk_downloader;
@@ -449,12 +448,12 @@ uint64 STDCALL snowflake_num_fields(SF_STMT *sfstmt);
 const char *STDCALL snowflake_sqlstate(SF_STMT *sfstmt);
 
 /**
- * Gets an array of column metadata.
+ * Gets an array of column metadata. The value returned by snowflake_num_fields is the size of the column metadata array
  *
  * @param sf SNOWFLAKE_STMT context.
  * @return SF_COLUMN_DESC if success or NULL
  */
-SF_COLUMN_DESC** STDCALL snowflake_desc(SF_STMT *sfstmt);
+SF_COLUMN_DESC* STDCALL snowflake_desc(SF_STMT *sfstmt);
 
 /**
  * Prepares a statement.

--- a/libsnowflakeclient/lib/results.c
+++ b/libsnowflakeclient/lib/results.c
@@ -105,6 +105,8 @@ SF_C_TYPE snowflake_to_c_type(SF_TYPE type, int64 precision, int64 scale) {
         } else {
             return SF_C_TYPE_INT64;
         }
+    } else if (type == SF_TYPE_REAL) {
+        return SF_C_TYPE_FLOAT64;
     } else if (type == SF_TYPE_TIMESTAMP_LTZ ||
             type == SF_TYPE_TIMESTAMP_NTZ ||
             type == SF_TYPE_TIMESTAMP_TZ) {
@@ -207,47 +209,46 @@ char *value_to_string(void *value, size_t len, SF_C_TYPE c_type) {
     }
 }
 
-SF_COLUMN_DESC ** set_description(const cJSON *rowtype) {
+SF_COLUMN_DESC * set_description(const cJSON *rowtype) {
     int i;
     cJSON *blob;
     cJSON *column;
-    SF_COLUMN_DESC **desc = NULL;
+    SF_COLUMN_DESC *desc = NULL;
     size_t array_size = (size_t) cJSON_GetArraySize(rowtype);
     if (rowtype == NULL || array_size == 0) {
         return desc;
     }
-    desc = (SF_COLUMN_DESC **) SF_CALLOC(array_size, sizeof(SF_COLUMN_DESC *));
+    desc = (SF_COLUMN_DESC *) SF_CALLOC(array_size, sizeof(SF_COLUMN_DESC));
     for (i = 0; i < array_size; i++) {
         column = cJSON_GetArrayItem(rowtype, i);
-        desc[i] = (SF_COLUMN_DESC *) SF_CALLOC(1, sizeof(SF_COLUMN_DESC));
-        if(json_copy_string(&desc[i]->name, column, "name")) {
-            desc[i]->name = NULL;
+        if(json_copy_string(&desc[i].name, column, "name")) {
+            desc[i].name = NULL;
         }
-        if (json_copy_int(&desc[i]->byte_size, column, "byteLength")) {
-            desc[i]->byte_size = 0;
+        if (json_copy_int(&desc[i].byte_size, column, "byteLength")) {
+            desc[i].byte_size = 0;
         }
-        if (json_copy_int(&desc[i]->internal_size, column, "length")) {
-            desc[i]->internal_size = 0;
+        if (json_copy_int(&desc[i].internal_size, column, "length")) {
+            desc[i].internal_size = 0;
         }
-        if (json_copy_int(&desc[i]->precision, column, "precision")) {
-            desc[i]->precision = 0;
+        if (json_copy_int(&desc[i].precision, column, "precision")) {
+            desc[i].precision = 0;
         }
-        if (json_copy_int(&desc[i]->scale, column, "scale")) {
-            desc[i]->scale = 0;
+        if (json_copy_int(&desc[i].scale, column, "scale")) {
+            desc[i].scale = 0;
         }
-        if (json_copy_bool(&desc[i]->null_ok, column, "nullable")) {
-            desc[i]->null_ok = SF_BOOLEAN_FALSE;
+        if (json_copy_bool(&desc[i].null_ok, column, "nullable")) {
+            desc[i].null_ok = SF_BOOLEAN_FALSE;
         }
         // Get type
         blob = cJSON_GetObjectItem(column, "type");
         if (cJSON_IsString(blob)) {
-            desc[i]->type = string_to_snowflake_type(blob->valuestring);
+            desc[i].type = string_to_snowflake_type(blob->valuestring);
         } else {
             // TODO Replace with default type
-            desc[i]->type = SF_TYPE_FIXED;
+            desc[i].type = SF_TYPE_FIXED;
         }
-        desc[i]->c_type = snowflake_to_c_type(desc[i]->type, desc[i]->precision, desc[i]->scale);
-        log_debug("Found type and ctype; %i: %i", desc[i]->type, desc[i]->c_type);
+        desc[i].c_type = snowflake_to_c_type(desc[i].type, desc[i].precision, desc[i].scale);
+        log_debug("Found type and ctype; %i: %i", desc[i].type, desc[i].c_type);
 
     }
 

--- a/libsnowflakeclient/lib/results.h
+++ b/libsnowflakeclient/lib/results.h
@@ -22,7 +22,7 @@ SF_TYPE string_to_snowflake_type(const char *string);
 SF_C_TYPE snowflake_to_c_type(SF_TYPE type, int64 precision, int64 scale);
 SF_TYPE c_type_to_snowflake(SF_C_TYPE c_type, SF_TYPE tsmode);
 char *value_to_string(void *value, size_t len, SF_C_TYPE c_type);
-SF_COLUMN_DESC ** set_description(const cJSON *rowtype);
+SF_COLUMN_DESC * set_description(const cJSON *rowtype);
 
 #ifdef __cplusplus
 }

--- a/libsnowflakeclient/lib/snowflake_client.c
+++ b/libsnowflakeclient/lib/snowflake_client.c
@@ -508,8 +508,7 @@ static void STDCALL _snowflake_stmt_desc_reset(SF_STMT *sfstmt) {
     if (sfstmt->desc) {
         /* column metadata */
         for (i = 0; i < sfstmt->total_fieldcount; i++) {
-            SF_FREE(sfstmt->desc[i]->name);
-            SF_FREE(sfstmt->desc[i]);
+            SF_FREE(sfstmt->desc[i].name);
         }
         SF_FREE(sfstmt->desc);
     }
@@ -711,7 +710,7 @@ SF_STATUS STDCALL snowflake_fetch(SF_STMT *sfstmt) {
         if (result == NULL) {
             continue;
         } else {
-            if (result->c_type != sfstmt->desc[i]->c_type && result->c_type != SF_C_TYPE_STRING) {
+            if (result->c_type != sfstmt->desc[i].c_type && result->c_type != SF_C_TYPE_STRING) {
                 // TODO add error msg
                 goto cleanup;
             }
@@ -732,7 +731,7 @@ SF_STATUS STDCALL snowflake_fetch(SF_STMT *sfstmt) {
             raw_result = cJSON_GetArrayItem(row, i);
             switch(result->c_type) {
                 case SF_C_TYPE_INT8:
-                    if (sfstmt->desc[i]->type == SF_TYPE_BOOLEAN) {
+                    if (sfstmt->desc[i].type == SF_TYPE_BOOLEAN) {
                         *(int8 *) result->value = cJSON_IsTrue(raw_result) ? SF_BOOLEAN_TRUE : SF_BOOLEAN_FALSE;
                     } else {
                         // field is a char?
@@ -757,7 +756,7 @@ SF_STATUS STDCALL snowflake_fetch(SF_STMT *sfstmt) {
                     result->len = sizeof(float64);
                     break;
                 case SF_C_TYPE_STRING:
-                    if (sfstmt->desc[i]->type == SF_TYPE_BOOLEAN) {
+                    if (sfstmt->desc[i].type == SF_TYPE_BOOLEAN) {
                         if (strcmp(raw_result->valuestring, "0") == 0) {
                             /* False */
                             strncpy(result->value, SF_BOOLEAN_FALSE_STR, result->max_length);
@@ -1122,7 +1121,7 @@ const char *STDCALL snowflake_sqlstate(SF_STMT *sfstmt) {
     return sfstmt->error.sqlstate;
 }
 
-SF_COLUMN_DESC** STDCALL snowflake_desc(SF_STMT *sfstmt) {
+SF_COLUMN_DESC* STDCALL snowflake_desc(SF_STMT *sfstmt) {
     if (!sfstmt) {
         return NULL;
     }


### PR DESCRIPTION
I changed the description interface to be an array of structs instead of an array of struct pointers. This reduces the number of memory allocations we have to do from (n + 1) to just 1 (amount of memory doesn't change, just number of memory allocation calls). Added support for REAL data type from Snowflake and added a test case to ensure we determine the right c_type in the column descriptions.