### PR TITLE
Added TIMEZONE_LTZ support

### DIFF
--- a/libsnowflakeclient/examples/CMakeLists.txt
+++ b/libsnowflakeclient/examples/CMakeLists.txt
@@ -22,6 +22,7 @@ SET(EXAMPLES
         timezone
         selectnull
         selecttsntz
+        selecttsltz
         check_ctypes)
 
 set(SOURCE_UTILS

--- a/libsnowflakeclient/examples/selecttsltz.c
+++ b/libsnowflakeclient/examples/selecttsltz.c
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2017 Snowflake Computing, Inc. All rights reserved.
+ */
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <snowflake_client.h>
+#include <example_setup.h>
+#include <string.h>
+
+
+#define USER_TZ "America/New_York"
+
+int main() {
+    /* init */
+    SF_STATUS status;
+    const char *tz = USER_TZ;
+
+    /* The client application must set the same timezone to both:
+     * 1) the environment variable TZ
+     * 2) the session parameter of Snowflake
+     * */
+    // setenv("TZ", tz, 1);
+    initialize_snowflake_example(SF_BOOLEAN_FALSE);
+    SF_CONNECT *sf = setup_snowflake_connection_with_autocommit(
+      tz, SF_BOOLEAN_TRUE);
+
+    status = snowflake_connect(sf);
+    if (status != SF_STATUS_SUCCESS) {
+        SF_ERROR *error = snowflake_error(sf);
+        fprintf(stderr, "Error message: %s\nIn File, %s, Line, %d\n",
+                error->msg, error->file, error->line);
+        goto cleanup;
+    }
+
+    /* Create a statement once and reused */
+    SF_STMT *sfstmt = snowflake_stmt(sf);
+    /* NOTE: the numeric type here should fit into int64 otherwise
+     * it is taken as a float */
+    status = snowflake_query(
+      sfstmt,
+      "create or replace table t (c1 int, c2 timestamp_ltz(5))",
+      0
+    );
+    if (status != SF_STATUS_SUCCESS) {
+        SF_ERROR *error = snowflake_stmt_error(sfstmt);
+        fprintf(stderr, "Error message: %s\nIn File, %s, Line, %d\n",
+                error->msg, error->file, error->line);
+        goto cleanup;
+    }
+
+    /* insert data */
+    status = snowflake_prepare(
+      sfstmt,
+      "insert into t(c1,c2) values(?,?)",
+      0);
+    if (status != SF_STATUS_SUCCESS) {
+        SF_ERROR *error = snowflake_stmt_error(sfstmt);
+        fprintf(stderr, "Error message: %s\nIn File, %s, Line, %d\n",
+                error->msg, error->file, error->line);
+        goto cleanup;
+    }
+
+    SF_BIND_INPUT ic1;
+    int64 ic1buf = 101;
+    ic1.idx = 1;
+    ic1.c_type = SF_C_TYPE_INT64;
+    ic1.value = (void *) &ic1buf;
+    ic1.len = sizeof(ic1buf);
+    snowflake_bind_param(sfstmt, &ic1);
+
+    SF_BIND_INPUT ic2;
+    char ic2buf[1024];
+
+    const char *r1 = "2014-05-03 13:56:46.00123 -04:00";
+    strcpy(ic2buf, r1);
+    ic2.idx = 2;
+    ic2.c_type = SF_C_TYPE_STRING;
+    ic2.value = (void *) ic2buf;
+    ic2.len = strlen(ic2buf);
+    snowflake_bind_param(sfstmt, &ic2);
+
+    status = snowflake_execute(sfstmt);
+    if (status != SF_STATUS_SUCCESS) {
+        SF_ERROR *error = snowflake_stmt_error(sfstmt);
+        fprintf(stderr, "Error message: %s\nIn File, %s, Line, %d\n",
+                error->msg, error->file, error->line);
+        goto cleanup;
+    }
+    printf("Inserted one row\n");
+
+    ic1buf = 102;
+    ic1.idx = 1;
+    ic1.c_type = SF_C_TYPE_INT64;
+    ic1.value = (void *) &ic1buf;
+    ic1.len = sizeof(ic1buf);
+    snowflake_bind_param(sfstmt, &ic1);
+
+    const char *r2 = "1969-11-21 05:17:23.12300 -05:00";
+    strcpy(ic2buf, r2);
+    ic2.idx = 2;
+    ic2.c_type = SF_C_TYPE_STRING;
+    ic2.value = (void *) ic2buf;
+    ic2.len = strlen(ic2buf);
+    snowflake_bind_param(sfstmt, &ic2);
+
+    status = snowflake_execute(sfstmt);
+    if (status != SF_STATUS_SUCCESS) {
+        SF_ERROR *error = snowflake_stmt_error(sfstmt);
+        fprintf(stderr, "Error message: %s\nIn File, %s, Line, %d\n",
+                error->msg, error->file, error->line);
+        goto cleanup;
+    }
+    printf("Inserted one row\n");
+
+    /* query */
+    status = snowflake_query(sfstmt, "select * from t", 0);
+    if (status != SF_STATUS_SUCCESS) {
+        SF_ERROR *error = snowflake_stmt_error(sfstmt);
+        fprintf(stderr, "Error message: %s\nIn File, %s, Line, %d\n",
+                error->msg, error->file, error->line);
+        goto cleanup;
+    }
+
+    SF_BIND_OUTPUT c1;
+    char c1buf[1024];
+    c1.idx = 1;
+    c1.c_type = SF_C_TYPE_STRING;
+    c1.value = (void *) c1buf;
+    c1.len = sizeof(c1buf);
+    c1.max_length = sizeof(c1buf);
+    snowflake_bind_result(sfstmt, &c1);
+
+    SF_BIND_OUTPUT c2;
+    char c2buf[1024];
+    c2.idx = 2;
+    c2.c_type = SF_C_TYPE_STRING;
+    c2.value = (void *) c2buf;
+    c2.len = sizeof(c2buf);
+    c2.max_length = sizeof(c2buf);
+    snowflake_bind_result(sfstmt, &c2);
+
+    printf("Number of rows: %d\n", (int) snowflake_num_rows(sfstmt));
+
+    int counter = 0;
+    while ((status = snowflake_fetch(sfstmt)) == SF_STATUS_SUCCESS) {
+        printf("result: %s, '%s'\n", (char *) c1.value, (char *) c2.value);
+        if (counter == 0) {
+            if (strcmp(r1, c2.value) != 0) {
+                fprintf(stderr, "expected: %s, got: %s\n", r1,
+                        (char *) c2.value);
+            }
+        } else {
+            if (strcmp(r2, c2.value) != 0) {
+                fprintf(stderr, "expected: %s, got: %s\n", r2,
+                        (char *) c2.value);
+            }
+        }
+        ++counter;
+    }
+
+    // If we reached end of line, then we were successful
+    if (status == SF_STATUS_EOL) {
+        status = SF_STATUS_SUCCESS;
+    } else if (status == SF_STATUS_ERROR || status == SF_STATUS_WARNING) {
+        SF_ERROR *error = snowflake_stmt_error(sfstmt);
+        fprintf(stderr, "Error message: %s\nIn File, %s, Line, %d\n",
+                error->msg, error->file, error->line);
+    }
+
+cleanup:
+    /* delete statement */
+    snowflake_stmt_term(sfstmt);
+
+    /* close and term */
+    snowflake_term(sf); // purge snowflake context
+    snowflake_global_term();
+
+    return status;
+}

--- a/libsnowflakeclient/include/snowflake_client.h
+++ b/libsnowflakeclient/include/snowflake_client.h
@@ -207,6 +207,9 @@ typedef struct sf_snowflake_connection {
     sf_bool autocommit;
     char *timezone;
 
+    /* used when updating parameters */
+    pthread_mutex_t mutex_parameters;
+
     char *authenticator;
 
     // Overrider application name and version

--- a/snowflake_stmt.c
+++ b/snowflake_stmt.c
@@ -165,14 +165,10 @@ static int pdo_snowflake_stmt_execute_prepared(pdo_stmt_t *stmt) /* {{{ */
                 break;
             case SF_TYPE_DATE:
             case SF_TYPE_TIMESTAMP_NTZ:
-                len = (size_t) 64; /* TODO: YYYY-MM-DD, MON DD, YYYY, etc */
-                break;
-            case SF_TYPE_TIME:
-                break;
             case SF_TYPE_TIMESTAMP_LTZ:
-                break;
             case SF_TYPE_TIMESTAMP_TZ:
-                break;
+            case SF_TYPE_TIME:
+                len = (size_t) 64; /* TODO: YYYY-MM-DD, MON DD, YYYY, etc */
                 break;
             default:
                 break;

--- a/tests/selectltz.phpt
+++ b/tests/selectltz.phpt
@@ -1,5 +1,5 @@
 --TEST--
-pdo_snowflake - insert and select DATE data type
+pdo_snowflake - insert and select TIMESTAMP_LTZ data type
 --INI--
 pdo_snowflake.cacert=libsnowflakeclient/cacert.pem
 --FILE--
@@ -7,12 +7,15 @@ pdo_snowflake.cacert=libsnowflakeclient/cacert.pem
     include __DIR__ . "/common.php";
 
     try {
+        $tz="America/New_York";
+        date_default_timezone_set($tz);
+        $dsn .=sprintf(";timezone=%s", $tz);
         $dbh = new PDO($dsn, $user, $password);
         $dbh->setAttribute( PDO::ATTR_ERRMODE, PDO::ERRMODE_WARNING );
         echo "Connected to Snowflake\n";
 
         /* INSERT bool */
-        $count = $dbh->exec("create or replace table t (c1 int, c2 date)");
+        $count = $dbh->exec("create or replace table t (c1 int, c2 timestamp_ltz)");
         if ($count == 0) {
             print_r($dbh->errorInfo());
         }
@@ -20,8 +23,13 @@ pdo_snowflake.cacert=libsnowflakeclient/cacert.pem
         $v1 = 101;
         $sth->bindParam(1, $v1);
         $v2 = new DateTime("now");
-        $v2str = $v2->format("Y-m-d");
+        $v2str = $v2->format("Y-m-d H:i:s.u000 P");
         $sth->bindParam(2, $v2str); // must convert to str
+        $sth->execute();
+
+        $sth->bindValue(1, 102);
+        $v2str2 = "1969-11-21 08:19:34.123000000 -05:00";
+        $sth->bindValue(2, $v2str2);
         $sth->execute();
 
         /* SELECT date */
@@ -31,12 +39,30 @@ pdo_snowflake.cacert=libsnowflakeclient/cacert.pem
         $meta = $sth->getColumnMeta(1);
         print_r($meta);
             echo "Results in String\n";
+        $cnt = 0;
         while($row = $sth->fetch()) {
-            echo sprintf("C1: %s, C2: (TODAY)\n", $row[0]);
-            if ($row[1] != $v2str) {
-                echo sprintf("Incorrect Value. expected: %s, got: %s\n",
-                $v2str, $row[1]);
+            echo sprintf("C1: %s, C2: ", $row[0]);
+            switch($cnt) {
+            case 0:
+                if (substr($row[1], 0, strlen($v2str)) != $v2str) {
+                    echo sprintf("Incorrect Value. expected: %s, got: %s\n",
+                    $v2str, $row[1]);
+                } else {
+                    echo "(TODAY)\n";
+                }
+                break;
+            case 1:
+                if (substr($row[1], 0, strlen($v2str2)) != $v2str2) {
+                    echo sprintf("Incorrect Value. expected: %s, got: %s\n",
+                    $v2str2, $row[1]);
+                } else {
+                    echo "(OLD DATE)\n";
+                }
+                break;
+            default:
+                break;
             }
+            ++$cnt;
         }
         $count = $dbh->exec("drop table if exists t");
 
@@ -66,8 +92,8 @@ Array
 )
 Array
 (
-    [scale] => 0
-    [native_type] => DATE
+    [scale] => 9
+    [native_type] => TIMESTAMP_LTZ
     [flags] => Array
         (
         )
@@ -79,4 +105,5 @@ Array
 )
 Results in String
 C1: 101, C2: (TODAY)
+C1: 102, C2: (OLD DATE)
 ===DONE===

--- a/tests/selectntz.phpt
+++ b/tests/selectntz.phpt
@@ -42,7 +42,7 @@ pdo_snowflake.cacert=libsnowflakeclient/cacert.pem
             switch($cnt) {
             case 0:
                 if (substr($row[1], 0, strlen($v2str)) != $v2str) {
-                    echo sprintf("Incorrect Value. expected: %s, got: %s",
+                    echo sprintf("Incorrect Value. expected: %s, got: %s\n",
                     $v2str, $row[1]);
                 } else {
                     echo "(TODAY)\n";
@@ -50,7 +50,7 @@ pdo_snowflake.cacert=libsnowflakeclient/cacert.pem
                 break;
             case 1:
                 if (substr($row[1], 0, strlen($v2str2)) != $v2str2) {
-                    echo sprintf("Incorrect Value. expected: %s, got: %s",
+                    echo sprintf("Incorrect Value. expected: %s, got: %s\n",
                     $v2str, $row[1]);
                 } else {
                     echo "(OLD DATE)\n";


### PR DESCRIPTION
- Added TIMESTAMP_LTZ support for PHP. When binding, the timestamp string must include the timezone offset, e.g., `1969-11-21 08:19:34.123000000 -05:00`
- Update `timezone` based on the response from the server.
- Added `static` to the existing functions, which are visible only in the file.

NOTE: C API uses the Snowflake session parameter `TIMEZONE` for the local timestamp conversion. This way, the application doesn't need to set the environment variable `TZ` but the session parameter. 