### PR TITLE
Added exception if the user tries to bind a named parameter

### DIFF
--- a/snowflake_stmt.c
+++ b/snowflake_stmt.c
@@ -429,6 +429,12 @@ static int pdo_snowflake_stmt_param_hook(
         /* nop if not binding parameter but column */
         PDO_LOG_RETURN(1);
     }
+    if (param->paramno == -1) {
+        // If paramno is -1, then this is a named parameter which is not supported yet
+        pdo_raise_impl_error(stmt->dbh, stmt, SF_SQLSTATE_OPTIONAL_FEATURE_NOT_IMPLEMENTED,
+          "Named parameters are not supported yet in the Snowflake PDO Driver");
+        PDO_LOG_RETURN(0);
+    }
     if (Z_ISREF(param->parameter)) {
         parameter = Z_REFVAL(param->parameter);
     } else {

--- a/tests/bind_named_parameters.phpt
+++ b/tests/bind_named_parameters.phpt
@@ -1,0 +1,32 @@
+--TEST--
+pdo_snowflake - binding
+--INI--
+pdo_snowflake.cacert=libsnowflakeclient/cacert.pem
+--FILE--
+<?php
+    include __DIR__ . "/common.php";
+
+    $dbh = new PDO($dsn, $user, $password);
+    $dbh->setAttribute( PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION );
+    echo "Connected to Snowflake\n";
+    $count = $dbh->exec("create or replace table t (c1 int, c2 string)");
+    if ($count == 0) {
+        print_r($dbh->errorInfo());
+    }
+
+    $sth = $dbh->prepare("insert into t(c1,c2) values(:number,:string)");
+
+    // Binding a named parameter should throw an error
+    try {
+        $i = 11;
+        $sth->bindParam(':number', $i);
+    } catch (Exception $e) {
+        echo 'Caught exception: ', $e->getMessage(), "\n";
+    }
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECT--
+Connected to Snowflake
+Caught exception: SQLSTATE[HYC00]: Optional feature not implemented: Named parameters are not supported yet in the Snowflake PDO Driver
+===DONE===


### PR DESCRIPTION
Added exception if the user tries to bind a named parameter (not supported yet). This prevents the driver from segfaulting.