### PR TITLE
Fix driver version to match the latest tag

### DIFF
--- a/php_pdo_snowflake.h
+++ b/php_pdo_snowflake.h
@@ -11,7 +11,7 @@ extern zend_module_entry pdo_snowflake_module_entry;
 /**
  * PHP PDO Snowflake version for PHP info
  */
-#define PDO_SNOWFLAKE_VERSION "0.2.1"
+#define PDO_SNOWFLAKE_VERSION "0.2.2"
 
 #ifdef PHP_WIN32
 #define PHP_PDO_SNOWFLAKE_API __declspec(dllexport)


### PR DESCRIPTION
Just noticed that driver compiled from v0.2.2 tag shows its version as 0.2.1 in logs. 