### PR TITLE
Decouple Test Setup from Build Process

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -334,7 +334,7 @@ Call :code:`env.sh` script to set the test connection parameters in the environm
 
 .. code-block:: bash
 
-    source ./scripts/env.sh
+    ./scripts/env.sh && env | grep SNOWFLAKE_TEST > testenv.ini
 
 Proxy
 ^^^^^^^^^^

--- a/scripts/build_pdo_snowflake.sh
+++ b/scripts/build_pdo_snowflake.sh
@@ -91,6 +91,3 @@ fi
 (cd .libs && rm -f pdo_snowflake.la && ln -s ../pdo_snowflake.la pdo_snowflake.la)
 ./libtool --mode=install cp ./pdo_snowflake.la $(pwd)/modules
 
-source $DIR/env.sh
-
-env | grep SNOWFLAKE_TEST > $DIR/../testenv.ini


### PR DESCRIPTION
The Linux build script makes a call to the testing setup script (env.sh) after successfully building the pdo. The problem is that env.sh returns `exit 1` if it fails to find a parameters.json file for testing, causing the Linux build script to fail when the build was actually successful.

This call to env.sh is not in the Windows build, and it should not be coupled with the Linux build either.