### PR TITLE
Update scripts for windows and osx build

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -55,10 +55,12 @@ if test "$PHP_PDO_SNOWFLAKE" != "no"; then
   dnl # (or -Wl,-force_load in OS X) is ignored by libtool
   LDFLAGS="$LDFLAGS -fPIC"
   if test "$build_mac" == "yes"; then
+    LDFLAGS="$LDFLAGS -dynamiclib -undefined dynamic_lookup"
     LDFLAGS="$LDFLAGS -Wl,-force_load,$SNOWFLAKE_CLIENT_DIR/lib/darwin/libsnowflakeclient.a"
     LDFLAGS="$LDFLAGS -Wl,-force_load,$SNOWFLAKE_CLIENT_DIR/deps-build/darwin/openssl/lib/libcrypto.a"
     LDFLAGS="$LDFLAGS -Wl,-force_load,$SNOWFLAKE_CLIENT_DIR/deps-build/darwin/openssl/lib/libssl.a"
     LDFLAGS="$LDFLAGS -Wl,-force_load,$SNOWFLAKE_CLIENT_DIR/deps-build/darwin/curl/lib/libcurl.a"
+    LDFLAGS="$LDFLAGS -Wl,-force_load,$SNOWFLAKE_CLIENT_DIR/deps-build/darwin/oob/lib/libtelemetry.a"
     LDFLAGS="$LDFLAGS -Wl,-force_load,$SNOWFLAKE_CLIENT_DIR/deps-build/darwin/aws/lib/libaws-cpp-sdk-core.a"
     LDFLAGS="$LDFLAGS -Wl,-force_load,$SNOWFLAKE_CLIENT_DIR/deps-build/darwin/aws/lib/libaws-cpp-sdk-s3.a"
     LDFLAGS="$LDFLAGS -Wl,-force_load,$SNOWFLAKE_CLIENT_DIR/deps-build/darwin/azure/lib/libazure-storage-lite.a"
@@ -69,6 +71,7 @@ if test "$PHP_PDO_SNOWFLAKE" != "no"; then
     LDFLAGS="$LDFLAGS $SNOWFLAKE_CLIENT_DIR/deps-build/linux/openssl/lib/libcrypto.a"
     LDFLAGS="$LDFLAGS $SNOWFLAKE_CLIENT_DIR/deps-build/linux/openssl/lib/libssl.a"
     LDFLAGS="$LDFLAGS $SNOWFLAKE_CLIENT_DIR/deps-build/linux/curl/lib/libcurl.a"
+    LDFLAGS="$LDFLAGS $SNOWFLAKE_CLIENT_DIR/deps-build/linux/oob/lib/libtelemetry.a"
     LDFLAGS="$LDFLAGS $SNOWFLAKE_CLIENT_DIR/deps-build/linux/aws/lib64/libaws-cpp-sdk-core.a"
     LDFLAGS="$LDFLAGS $SNOWFLAKE_CLIENT_DIR/deps-build/linux/aws/lib64/libaws-cpp-sdk-s3.a"
     LDFLAGS="$LDFLAGS $SNOWFLAKE_CLIENT_DIR/deps-build/linux/azure/lib/libazure-storage-lite.a"

--- a/config.w32
+++ b/config.w32
@@ -7,10 +7,10 @@ ARG_WITH("pdo_snowflake", "for pdo_snowflake support", "no");
 
 if (PHP_PDO_SNOWFLAKE != "no") {
 
-    pdo_snowflake_src_files = " pdo_snowflake.c snowflake_driver.c snowflake_stmt.c snowflake_arraylist.c ";
+    pdo_snowflake_src_files = " pdo_snowflake.c snowflake_driver.c snowflake_stmt.c snowflake_paramstore.c snowflake_arraylist.c snowflake_treemap.c snowflake_rbtree.c ";
 
     if (CHECK_LIB('libsnowflakeclient_a.lib', 'pdo_snowflake') && CHECK_LIB('libcurl_a.lib', 'pdo_snowflake') && 
-            CHECK_LIB('libssl_a.lib', 'pdo_snowflake') && CHECK_LIB('libcrypto_a.lib', 'pdo_snowflake') && CHECK_LIB('zlib_a.lib', 'pdo_snowflake') && 
+            CHECK_LIB('libssl_a.lib', 'pdo_snowflake') && CHECK_LIB('libcrypto_a.lib', 'pdo_snowflake') && CHECK_LIB('zlib_a.lib', 'pdo_snowflake') && CHECK_LIB('libtelemetry_a.lib', 'pdo_snowflake') &&
             CHECK_HEADER_ADD_INCLUDE('snowflake\\client.h', 'CFLAGS_PDO_SNOWFLAKE', configure_module_dirname + '\\libsnowflakeclient\\include')) {
         STDOUT.WriteLine("INFO: Snowflake PDO Configuration");
         ADD_EXTENSION_DEP('pdo_snowflake', 'pdo');

--- a/scripts/build_pdo_snowflake.bat
+++ b/scripts/build_pdo_snowflake.bat
@@ -37,6 +37,19 @@ xcopy ^
     /v /y /e
 if %ERRORLEVEL% NEQ 0 goto :error
 
+:: Move Azure
+xcopy ^
+    "%pdodir%\libsnowflakeclient\deps-build\%build_dir%\azure\lib\*.lib" ^
+    "%depsdir%\lib\" ^
+    /v /y
+if %ERRORLEVEL% NEQ 0 goto :error
+:: No delete since no directory for azure headers
+xcopy ^
+    "%pdodir%\libsnowflakeclient\deps-build\%build_dir%\azure\include\*" ^
+    "%depsdir%\include\" ^
+    /v /y /e
+if %ERRORLEVEL% NEQ 0 goto :error
+
 :: Move Curl
 xcopy ^
     "%pdodir%\libsnowflakeclient\deps-build\%build_dir%\curl\lib\*.lib" ^
@@ -48,6 +61,19 @@ if %ERRORLEVEL% NEQ 0 goto :error
 xcopy ^
     "%pdodir%\libsnowflakeclient\deps-build\%build_dir%\curl\include\curl" ^
     "%depsdir%\include\curl\" ^
+    /v /y /e
+if %ERRORLEVEL% NEQ 0 goto :error
+
+:: Move oob
+xcopy ^
+    "%pdodir%\libsnowflakeclient\deps-build\%build_dir%\oob\lib\*.lib" ^
+    "%depsdir%\lib\" ^
+    /v /y
+if %ERRORLEVEL% NEQ 0 goto :error
+:: No delete since no directory for oob headers
+xcopy ^
+    "%pdodir%\libsnowflakeclient\deps-build\%build_dir%\oob\include\*" ^
+    "%depsdir%\include\" ^
     /v /y /e
 if %ERRORLEVEL% NEQ 0 goto :error
 

--- a/scripts/build_pdo_snowflake.sh
+++ b/scripts/build_pdo_snowflake.sh
@@ -60,6 +60,7 @@ if [[ "$PLATFORM" == "linux" ]]; then
         libsnowflakeclient/deps-build/linux/openssl/lib/libcrypto.a \
         libsnowflakeclient/deps-build/linux/openssl/lib/libssl.a \
         libsnowflakeclient/deps-build/linux/curl/lib/libcurl.a \
+        libsnowflakeclient/deps-build/linux/oob/lib/libtelemetry.a \
         libsnowflakeclient/deps-build/linux/aws/lib64/libaws-cpp-sdk-core.a \
         libsnowflakeclient/deps-build/linux/aws/lib64/libaws-cpp-sdk-s3.a \
         libsnowflakeclient/deps-build/linux/azure/lib/libazure-storage-lite.a \
@@ -75,7 +76,7 @@ if [[ "$PLATFORM" == "linux" ]]; then
 elif [[ "$PLATFORM" == "darwin" ]]; then
     # Darwin uses -force_load instead
     echo "Linking for Darwin"
-    cc -shared \
+    cc -dynamiclib -undefined dynamic_lookup \
         -g \
         .libs/snowflake_paramstore.o \
         .libs/snowflake_arraylist.o \
@@ -84,21 +85,15 @@ elif [[ "$PLATFORM" == "darwin" ]]; then
         .libs/pdo_snowflake.o \
         .libs/snowflake_driver.o \
         .libs/snowflake_stmt.o \
-        -L libsnowflakeclient/lib/darwin \
-        -L libsnowflakeclient/deps-build/darwin/openssl/lib \
-        -L libsnowflakeclient/deps-build/darwin/curl/lib \
-        -L libsnowflakeclient/deps-build/darwin/aws/lib \
-        -L libsnowflakeclient/deps-build/darwin/azure/lib \
-        -lsnowflakeclient \
-        -Wl,-force-load,crypto \
-        -Wl,-force-load,ssl \
-        -Wl,-force-load,curl \
-        -Wl,-force-load,pthread \
-        -Wl,-force-load,aws-cpp-sdk-core \
-        -Wl,-force-load,aws-cpp-sdk-s3 \
-        -Wl,-force-load,azure-storage-lite \
+        -Wl,-force_load,libsnowflakeclient/lib/darwin/libsnowflakeclient.a \
+        -Wl,-force_load,libsnowflakeclient/deps-build/darwin/openssl/lib/libcrypto.a \
+        -Wl,-force_load,libsnowflakeclient/deps-build/darwin/openssl/lib/libssl.a \
+        -Wl,-force_load,libsnowflakeclient/deps-build/darwin/curl/lib/libcurl.a \
+        -Wl,-force_load,libsnowflakeclient/deps-build/darwin/oob/lib/libtelemetry.a \
+        -Wl,-force_load,libsnowflakeclient/deps-build/darwin/aws/lib/libaws-cpp-sdk-core.a \
+        -Wl,-force_load,libsnowflakeclient/deps-build/darwin/aws/lib/libaws-cpp-sdk-s3.a \
+        -Wl,-force_load,libsnowflakeclient/deps-build/darwin/azure/lib/libazure-storage-lite.a \
         $LINK_OPTS \
-        -Wl,-soname -Wl,pdo_snowflake.so \
         -o .libs/pdo_snowflake.so
 fi
 (cd .libs && rm -f pdo_snowflake.la && ln -s ../pdo_snowflake.la pdo_snowflake.la)


### PR DESCRIPTION
To be able to build on Windows and OSX
Known issues:
Windows: Negative epoch (date before 1970-01-01)  could cause incorrect result on timestamp data retrieval on Windows.
Fix is made in libsnowflakeclient here: https://github.com/snowflakedb/libsnowflakeclient/pull/249
need to update libsnowflakeclient library when the fix is merged.
Linux: year with less then 2 digits is represented as 2 digits, not 4 digits. For an example the date 0001-12-01 will be represented as 01-12-01. On Windows and OSX it's represented as 0001-12-01. It's the behavior of strftime() and the result is acceptable. No plan to fix it.