### PR TITLE
Fix uuid symbol not found issue on Linux

### DIFF
--- a/scripts/build_pdo_snowflake.sh
+++ b/scripts/build_pdo_snowflake.sh
@@ -64,6 +64,7 @@ if [[ "$PLATFORM" == "linux" ]]; then
         libsnowflakeclient/deps-build/linux/aws/lib64/libaws-cpp-sdk-core.a \
         libsnowflakeclient/deps-build/linux/aws/lib64/libaws-cpp-sdk-s3.a \
         libsnowflakeclient/deps-build/linux/azure/lib/libazure-storage-lite.a \
+        libsnowflakeclient/deps-build/linux/uuid/lib/libuuid.a \
         -O2 \
         -Wl,--whole-archive \
         -Wl,--no-whole-archive \


### PR DESCRIPTION
When build the driver with pre-installed PHP (not installed from source code), get error of "undefined symbol: uuid_unparse_lower)" when loading the driver from PHP.

Link with uuid library on Linux to fix this issue.