### PR TITLE
SNOW-181550 Document cmake as a macOS requirement

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,10 @@ In order to build the Snowflake PHP PDO Driver, you must have the following soft
   - gcc 5.2 or higher
   - cmake
 
-- On macOS: clang
+- On macOS:
+
+  - clang
+  - cmake
 
 In order to install and use the Snowflake PHP PDO Driver, you must have the following software installed:
 

--- a/README.rst
+++ b/README.rst
@@ -23,12 +23,12 @@ In order to build the Snowflake PHP PDO Driver, you must have the following soft
 - On Linux:
 
   - gcc 5.2 or higher
-  - cmake
+  - cmake 2.8 or higher
 
 - On macOS:
 
   - clang
-  - cmake
+  - cmake 2.8 or higher
 
 In order to install and use the Snowflake PHP PDO Driver, you must have the following software installed:
 


### PR DESCRIPTION
# Overview

SNOW-181550

Description
Document cmake as a macOS requirement. If cmake is not installed, scripts/build_pdo_snowflake.sh exits silently after running
`which cmake`.

# Note to reviewers

When I tried this out on my macOS machine (which had clang installed but not cmake), the `scripts/build_pdo_snowflake.sh` exited without printing out any information.

Adding `-x` to the line with `set -o pipefail` produced this output:

```
% ./scripts/build_pdo_snowflake.sh 
++++ dirname /<path>/pdo_snowflake/scripts/_init.sh
+++ cd /<path>/pdo_snowflake/scripts
+++ pwd
++ DIR=/<path>/pdo_snowflake/scripts
+++ tr '[:upper:]' '[:lower:]'
++++ uname
+++ echo Darwin
++ PLATFORM=darwin
+++ which cmake3
++ [[ -n '' ]]
+++ which cmake
++ CMAKE=
%
```