### PR TITLE
SNOW-208979 Add option to trigger Github Action Build/Test manually

### DIFF
--- a/.github/workflows/BuildAndTest.yml
+++ b/.github/workflows/BuildAndTest.yml
@@ -9,6 +9,14 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        default: warning
+        description: "Log level"
+        required: true
+      tags:
+        description: "Test scenario tags"
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
This will add a button for build-test workflow to run it manually . This will be useful for Releng team to run PHP tests on master or any other branch as part of pre-release of server release is done to ensure it does not break PHP connector