### PR TITLE
bug fix: autocommit is turned over when creating connection with options

### DIFF
--- a/snowflake_driver.c
+++ b/snowflake_driver.c
@@ -588,7 +588,7 @@ pdo_snowflake_handle_factory(pdo_dbh_t *dbh, zval *driver_options) /* {{{ */
         /* auto commit */
         zend_long auto_commit = pdo_attr_lval(
             driver_options,
-            PDO_ATTR_AUTOCOMMIT, 1) ? 0 : 1;
+            PDO_ATTR_AUTOCOMMIT, 1);
 
         /*TODO: disable verify peer? do we need this option? */
         snowflake_global_set_attribute(

--- a/tests/connect.phpt
+++ b/tests/connect.phpt
@@ -9,7 +9,8 @@ pdo_snowflake.cacert=libsnowflakeclient/cacert.pem
     // full parameters
     $dbh = new PDO("$dsn;application=phptest", $user, $password);
     // create table for testing autocommit later
-    $count = $dbh->exec("create or replace table autocommittest(c1 int)");
+    $tablename = "autocommittest" . rand();
+    $count = $dbh->exec("create or replace table " . $tablename . "(c1 int)");
     if ($count == 0) {
         print_r($dbh->errorInfo());
     }
@@ -28,39 +29,39 @@ pdo_snowflake.cacert=libsnowflakeclient/cacert.pem
     // default to true
     $dbh = new PDO("$dsn;application=phptest", $user, $password, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
     // insert a row and the result will be tested later
-    $dbh->exec("insert into autocommittest values (1)");
+    $dbh->exec("insert into " . $tablename . " values (1)");
     $dbh = null;
 
     // set to true
     $dbh = new PDO("$dsn;application=phptest", $user, $password, [PDO::ATTR_AUTOCOMMIT => true]);
     // check the result of previous test
-    $sth = $dbh->query("select count(*) from autocommittest");
+    $sth = $dbh->query("select count(*) from " . $tablename);
     while($row = $sth->fetch()) {
         echo $row[0] . "\n";
     }
     // insert a row and the result will be tested later
-    $dbh->exec("insert into autocommittest values (2)");
+    $dbh->exec("insert into " . $tablename . " values (2)");
     $dbh = null;
 
     // set to false
     $dbh = new PDO("$dsn;application=phptest", $user, $password, [PDO::ATTR_AUTOCOMMIT => false]);
     // check the result of previous test
-    $sth = $dbh->query("select count(*) from autocommittest");
+    $sth = $dbh->query("select count(*) from " . $tablename);
     while($row = $sth->fetch()) {
         echo $row[0] . "\n";
     }
     // insert a row and the result will be tested later
-    $dbh->exec("insert into autocommittest values (3)");
+    $dbh->exec("insert into " . $tablename . " values (3)");
     $dbh = null;
 
     $dbh = new PDO("$dsn;application=phptest", $user, $password);
     // check the result of previous test
-    $sth = $dbh->query("select count(*) from autocommittest");
+    $sth = $dbh->query("select count(*) from " . $tablename);
     while($row = $sth->fetch()) {
         echo $row[0] . "\n";
     }
     // clean up
-    $count = $dbh->exec("drop table if exists autocommittest");
+    $count = $dbh->exec("drop table if exists " . $tablename);
     if ($count == 0) {
         print_r($dbh->errorInfo());
     }

--- a/tests/connect.phpt
+++ b/tests/connect.phpt
@@ -8,6 +8,11 @@ pdo_snowflake.cacert=libsnowflakeclient/cacert.pem
 
     // full parameters
     $dbh = new PDO("$dsn;application=phptest", $user, $password);
+    // create table for testing autocommit later
+    $count = $dbh->exec("create or replace table autocommittest(c1 int)");
+    if ($count == 0) {
+        print_r($dbh->errorInfo());
+    }
     $dbh = null;
 
     if (!array_key_exists('SNOWFLAKE_TEST_HOST', $p)) {
@@ -18,10 +23,55 @@ pdo_snowflake.cacert=libsnowflakeclient/cacert.pem
         $dbh = null;
     }
     echo "OK\n";
+
+    // test auto commit in connect options
+    // default to true
+    $dbh = new PDO("$dsn;application=phptest", $user, $password, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+    // insert a row and the result will be tested later
+    $dbh->exec("insert into autocommittest values (1)");
+    $dbh = null;
+
+    // set to true
+    $dbh = new PDO("$dsn;application=phptest", $user, $password, [PDO::ATTR_AUTOCOMMIT => true]);
+    // check the result of previous test
+    $sth = $dbh->query("select count(*) from autocommittest");
+    while($row = $sth->fetch()) {
+        echo $row[0] . "\n";
+    }
+    // insert a row and the result will be tested later
+    $dbh->exec("insert into autocommittest values (2)");
+    $dbh = null;
+
+    // set to false
+    $dbh = new PDO("$dsn;application=phptest", $user, $password, [PDO::ATTR_AUTOCOMMIT => false]);
+    // check the result of previous test
+    $sth = $dbh->query("select count(*) from autocommittest");
+    while($row = $sth->fetch()) {
+        echo $row[0] . "\n";
+    }
+    // insert a row and the result will be tested later
+    $dbh->exec("insert into autocommittest values (3)");
+    $dbh = null;
+
+    $dbh = new PDO("$dsn;application=phptest", $user, $password);
+    // check the result of previous test
+    $sth = $dbh->query("select count(*) from autocommittest");
+    while($row = $sth->fetch()) {
+        echo $row[0] . "\n";
+    }
+    // clean up
+    $count = $dbh->exec("drop table if exists autocommittest");
+    if ($count == 0) {
+        print_r($dbh->errorInfo());
+    }
+    $dbh = null;
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECT--
 OK
+1
+2
+2
 ===DONE===
 


### PR DESCRIPTION
Simba ticket 00388800.
When creating connection with options (the last argument) like:
$pdoConnection = new PDO($dsn, $user, $password, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
auto commit is turned off which caused queries were silently rolled back later.
The root cause was a simple copy mistake. It make sense to turn over PDO_SNOWFLAKE_ATTR_SSL_VERIFY_CERTIFICATE_REVOCATION_STATUS because "verify=true" means "disable_verify = false" but no need to do that for auto commit.
