### PR TITLE
[#87] Add composer.json and composer.lock files for snyk test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ testenv.ini
 gmon.out
 callgrind.out.*
 configure.ac
+vendor/

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "snowflakedb/pdo_snowflake",
+    "description": "PHP PDO driver for Snowflake",
+    "require": {
+        "php": ">=7.4"
+    },
+    "authors": [
+        {
+            "name": "Snowflake Computing, Inc.",
+            "email": "support@snowflake.com",
+            "homepage": "https://www.snowflake.com/"
+        }
+    ],
+    "license": "Apache-2.0"
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,20 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "a501367f22460d5f4b4b8902388dcf2b",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=7.4"
+    },
+    "platform-dev": [],
+    "plugin-api-version": "2.3.0"
+}


### PR DESCRIPTION
Request: https://github.com/snowflakedb/snowflake-sdks-drivers-issues-teamwork/issues/87
Snyk requirements for PHP: https://docs.snyk.io/scan-application-code/snyk-open-source/language-and-package-manager-support/snyk-for-php

Files changed:
- composer.json: This file describes the dependencies of the project and other metadata.
- composer.lock: This file is generated from composer.json and locks the project to specific versions of all packages.
- .gitignore: added the vendor folder as we don't want to add all of the third-party code to the repo repository. This is recommended by the composer docs.
Composer docs: https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies

Snyk only supports Composer for PHP which requires the composer.json and composer.lock files to be present in the repository. However, the PHP driver is written in C and it only needs dependencies from libsnowflakeclient. Snyk test result will show 1 dependency only which is the minimum PHP version.
```
"require": {
    "php": ">=7.4"
}
```

Snyk test result:
```
C:\GitRepo\SNOW-665303-snyk-test\pdo_snowflake>snyk test

Testing C:\GitRepo\SNOW-665303-snyk-test\pdo_snowflake...

Organization:      sfc-gh-ext-simba-jl
Package manager:   composer
Target file:       composer.lock
Project name:      snowflakedb/pdo_snowflake
Open source:       no
Project path:      C:\GitRepo\SNOW-665303-snyk-test\pdo_snowflake
Licenses:          enabled

✔ Tested 1 dependencies for known issues, no vulnerable paths found.
```