### PR TITLE
add support for ATTR_CLINET_VERSION

### DIFF
--- a/snowflake_driver.c
+++ b/snowflake_driver.c
@@ -405,6 +405,10 @@ pdo_snowflake_get_attribute(pdo_dbh_t *dbh, zend_long attr,
             ZVAL_LONG(return_value, dbh->auto_commit);
             PDO_LOG_RETURN(1);
             break;
+        case PDO_ATTR_CLIENT_VERSION:
+            ZVAL_STRINGL(return_value, PDO_SNOWFLAKE_VERSION, strlen(PDO_SNOWFLAKE_VERSION));
+            PDO_LOG_RETURN(1);
+            break;
         default:
             /**/
             PDO_LOG_RETURN(0);

--- a/tests/getattribute.phpt
+++ b/tests/getattribute.phpt
@@ -36,6 +36,13 @@ pdo_snowflake.cacert=libsnowflakeclient/cacert.pem
     $f5 = (strpos($pinfo, "pdo_snowflake.loglevel") === false);
     echo (int)$f1 . " " . (int)$f2 . " " . (int)$f3 . " " . (int)$f4 . " " . (int)$f5 . "\n";
 
+    $driver_ver = $dbh->getAttribute(PDO::ATTR_CLIENT_VERSION);
+    if (strcmp($driver_ver, '1.2.7') >= 0) {
+        echo "Successfully get dirver version " . $driver_ver . "\n";
+    }
+    else {
+        echo "Failed get dirver version.\n";
+    }
 ?>
 ===DONE===
 <?php exit(0); ?>
@@ -48,4 +55,5 @@ PDO::ATTR_PERSISTENT:
 PDO::ATTR_AUTOCOMMIT: 1
 PDO::ATTR_AUTOCOMMIT: 0
 0 0 0 0 0
+Successfully get dirver version 1.2.7
 ===DONE===

--- a/tests/getattribute.phpt
+++ b/tests/getattribute.phpt
@@ -38,7 +38,8 @@ pdo_snowflake.cacert=libsnowflakeclient/cacert.pem
 
     $driver_ver = $dbh->getAttribute(PDO::ATTR_CLIENT_VERSION);
     if (strcmp($driver_ver, '1.2.7') >= 0) {
-        echo "Successfully get dirver version " . $driver_ver . "\n";
+        // comment out driver version to avoid update test case for each release
+        echo "Successfully get dirver version " . /*$driver_ver .*/ "\n";
     }
     else {
         echo "Failed get dirver version.\n";
@@ -55,5 +56,5 @@ PDO::ATTR_PERSISTENT:
 PDO::ATTR_AUTOCOMMIT: 1
 PDO::ATTR_AUTOCOMMIT: 0
 0 0 0 0 0
-Successfully get dirver version 1.2.7
+Successfully get dirver version 
 ===DONE===


### PR DESCRIPTION
sdk issue 585
Add support for ATTR_CLIENT_VERSION to allow getting driver version through API.
Will remove the exact version number from test case to avoid test case update for each release. Test in once though to ensure it's working.
Now the application can use PDO::getAttribute(PDO::ATTR_CLIENT_VERSION) https://www.php.net/manual/en/pdo.getattribute.php to retrieve the driver version.