### PR TITLE
Fix Visual Studio 2019 target prefix

### DIFF
--- a/scripts/_init.bat
+++ b/scripts/_init.bat
@@ -54,7 +54,7 @@ set vc_version=
 if "%vs_version%"=="VS16" (
     set cmake_generator=Visual Studio 16 2019
     set vsdir=vs16
-    set vc_version=vc16
+    set vc_version=vs16
 )
 if "%vs_version%"=="VS15" (
     set cmake_generator=Visual Studio 15 2017


### PR DESCRIPTION
The trivial fix of Windows build script to set correct Visual Studio version for VS16.
The correct VC++ version for Visual Studio 2019 is `vs16`, not `vc16`, otherwise no dep libs will be downloaded from https://windows.php.net/downloads/php-sdk/deps/

Closing #333

