### PR TITLE
SNOW-726743: [HTAP] LAST QUERY ID - Driver API for PHP/PDO

### DIFF
--- a/pdo_snowflake.c
+++ b/pdo_snowflake.c
@@ -74,6 +74,10 @@ static PHP_MINIT_FUNCTION(pdo_snowflake) {
       "SNOWFLAKE_ATTR_SSL_VERIFY_CERTIFICATE_REVOCATION_STATUS",
       (zend_long) PDO_SNOWFLAKE_ATTR_SSL_VERIFY_CERTIFICATE_REVOCATION_STATUS);
 
+    REGISTER_PDO_CLASS_CONST_LONG(
+      "SNOWFLAKE_ATTR_QUERY_ID",
+      (zend_long) PDO_SNOWFLAKE_ATTR_QUERY_ID);
+
     return php_pdo_register_driver(&pdo_snowflake_driver);
 }
 /* }}} */

--- a/php_pdo_snowflake_int.h
+++ b/php_pdo_snowflake_int.h
@@ -46,6 +46,7 @@ typedef struct {
 
 typedef struct {
     SF_CONNECT *server;
+    char last_qid[SF_UUID4_LEN];
 } pdo_snowflake_db_handle;
 
 typedef struct {
@@ -74,7 +75,8 @@ extern void _pdo_snowflake_user_dealloc(void* ptr);
 enum {
     PDO_SNOWFLAKE_ATTR_SSL_CAPATH = PDO_ATTR_DRIVER_SPECIFIC,
     PDO_SNOWFLAKE_ATTR_SSL_VERSION,
-    PDO_SNOWFLAKE_ATTR_SSL_VERIFY_CERTIFICATE_REVOCATION_STATUS
+    PDO_SNOWFLAKE_ATTR_SSL_VERIFY_CERTIFICATE_REVOCATION_STATUS,
+    PDO_SNOWFLAKE_ATTR_QUERY_ID
 };
 
 #define PDO_SNOWFLAKE_CONN_ATTR_HOST_IDX 0

--- a/snowflake_driver.c
+++ b/snowflake_driver.c
@@ -231,6 +231,8 @@ snowflake_handle_doer(pdo_dbh_t *dbh, const char *sql, size_t sql_len) /* {{{ */
 {
     PDO_LOG_ENTER("snowflake_handle_doer");
     int ret = 0;
+    SF_STATUS query_status;
+    const char * qid;
     pdo_snowflake_db_handle *H = (pdo_snowflake_db_handle *) dbh->driver_data;
     PDO_LOG_DBG("sql: %.*s, len: %d", sql_len, sql, sql_len);
     SF_STMT *sfstmt = snowflake_stmt(H->server);
@@ -239,7 +241,16 @@ snowflake_handle_doer(pdo_dbh_t *dbh, const char *sql, size_t sql_len) /* {{{ */
     snowflake_stmt_set_attr(sfstmt, SF_STMT_USER_REALLOC_FUNC,
                             _pdo_snowflake_user_realloc);
 
-    if (snowflake_query(sfstmt, sql, sql_len) == SF_STATUS_SUCCESS) {
+    query_status = snowflake_query(sfstmt, sql, sql_len);
+
+    //save query id if available
+    qid = snowflake_sfqid(sfstmt);
+    if (qid && (strlen(qid) > 0))
+    {
+        strncpy(H->last_qid, qid, sizeof(H->last_qid) - 1);
+    }
+
+    if (query_status == SF_STATUS_SUCCESS) {
         int64 rows = snowflake_affected_rows(sfstmt);
         if (rows == -1) {
             snowflake_propagate_error(H->server, sfstmt);
@@ -409,6 +420,10 @@ pdo_snowflake_get_attribute(pdo_dbh_t *dbh, zend_long attr,
             ZVAL_STRINGL(return_value, PDO_SNOWFLAKE_VERSION, strlen(PDO_SNOWFLAKE_VERSION));
             PDO_LOG_RETURN(1);
             break;
+        case PDO_SNOWFLAKE_ATTR_QUERY_ID:
+            ZVAL_STRINGL(return_value, H->last_qid, strlen(H->last_qid));
+            PDO_LOG_RETURN(1);
+            break;
         default:
             /**/
             PDO_LOG_RETURN(0);
@@ -573,6 +588,7 @@ pdo_snowflake_handle_factory(pdo_dbh_t *dbh, zval *driver_options) /* {{{ */
                               sizeof(struct pdo_data_src_parser));
 
     H = pecalloc(1, sizeof(pdo_snowflake_db_handle), dbh->is_persistent);
+    H->last_qid[0] = '\0';
 
     //TODO set error stuff
 

--- a/snowflake_stmt.c
+++ b/snowflake_stmt.c
@@ -680,7 +680,6 @@ int pdo_snowflake_stmt_get_attr(pdo_stmt_t *stmt, zend_long attr, zval *return_v
         PDO_LOG_RETURN(0);
     }
     pdo_snowflake_stmt *S = (pdo_snowflake_stmt *) stmt->driver_data;
-    PDO_LOG_RETURN(1);
 
     PDO_LOG_DBG("stmt=%p", stmt);
     PDO_LOG_DBG("attr=%l", attr);
@@ -705,7 +704,7 @@ struct pdo_stmt_methods snowflake_stmt_methods = {
   pdo_snowflake_stmt_get_col,
   pdo_snowflake_stmt_param_hook,
   NULL, /* set_attr */
-  NULL, /* get_attr */
+  pdo_snowflake_stmt_get_attr,
   pdo_snowflake_stmt_col_meta,
   pdo_snowflake_stmt_next_rowset,
   pdo_snowflake_stmt_cursor_closer

--- a/tests/getattribute.phpt
+++ b/tests/getattribute.phpt
@@ -44,6 +44,69 @@ pdo_snowflake.cacert=libsnowflakeclient/cacert.pem
     else {
         echo "Failed get driver version.\n";
     }
+
+    // query id with prepared query
+    $qid = $dbh->getAttribute(PDO::SNOWFLAKE_ATTR_QUERY_ID);
+    $sth = $dbh->prepare("select 1");
+    $sqid = $sth->getAttribute(PDO::SNOWFLAKE_ATTR_QUERY_ID);
+    if (!empty($qid) || !empty($sqid)) {
+        echo "query id is not empty before any query executed: " . $qid . ", " . $sqid . "\n";
+    }
+    else {
+        echo "query id is empty before any query executed.\n";
+    }
+    $sth->execute();
+    $qid = $dbh->getAttribute(PDO::SNOWFLAKE_ATTR_QUERY_ID);
+    $sqid = $sth->getAttribute(PDO::SNOWFLAKE_ATTR_QUERY_ID);
+    if ($qid != $sqid)
+    {
+        echo "query id from connecton is different from statement: " . $qid . ", " . $sqid . "\n";
+    }
+    else if (empty($qid)) {
+        echo "query id is empty after query executed.\n";
+    }
+    else {
+        echo "query id is valid after query executed.\n";
+    }
+
+    // query id with directly executed query
+    $sth = $dbh->query("create temporary table tb1(c1 varchar)");
+    $qid1 = $dbh->getAttribute(PDO::SNOWFLAKE_ATTR_QUERY_ID);
+    $sqid1 = $sth->getAttribute(PDO::SNOWFLAKE_ATTR_QUERY_ID);
+    if ($qid == $qid1)
+    {
+        echo "query id is not updated after another query executed.\n";
+    }
+    if ($qid1 != $sqid1)
+    {
+        echo "query id from connecton is different from statement: " . $qid . ", " . $sqid . "\n";
+    }
+    else if (empty($qid1)) {
+        echo "query id is empty after query executed.\n";
+    }
+    else {
+        echo "query id is valid after query executed.\n";
+    }
+
+    // query id with failed query
+    $sth = $dbh->query("select * from table_not_exists");
+    if ($sth !== false)
+    {
+        echo "unexpected query success.\n";
+    }
+
+    $qid2 = $dbh->getAttribute(PDO::SNOWFLAKE_ATTR_QUERY_ID);
+
+    if ($qid2 == $qid1)
+    {
+        echo "query id is not updated with failed query.\n";
+    }
+    if (empty($qid2)) {
+        echo "query id is empty with failed query.\n";
+    }
+    else {
+        echo "query id is valid with failed query.\n";
+    }
 ?>
 ===DONE===
 <?php exit(0); ?>
@@ -57,4 +120,8 @@ PDO::ATTR_AUTOCOMMIT: 1
 PDO::ATTR_AUTOCOMMIT: 0
 0 0 0 0 0
 Successfully get driver version 
+query id is empty before any query executed.
+query id is valid after query executed.
+query id is valid after query executed.
+query id is valid with failed query.
 ===DONE===


### PR DESCRIPTION
sdk issue124
In PDO the query execution is basically on connection level (.e.g using PDO::query https://www.php.net/manual/en/pdo.query.php) and the statement class is for one query returned from PDO::query(). https://www.php.net/manual/en/class.pdostatement.php
So the query id has to be saved on connection level. Especially for the failure case the PDO::query() return false and no statement instance available.

Add driver specific attribute SNOWFLAKE_ATTR_QUERY_ID can be used for PDO::getAttribute() and PDOStatement::getAttribute()
sample code:
```
    $dbh = new PDO("snowflake:account=<account_name>", "<user>", "<password>");
    $sth = $dbh->query("select 1");
    $qid = $dbh->getAttribute(PDO::SNOWFLAKE_ATTR_QUERY_ID);
    $sqid = $sth->getAttribute(PDO::SNOWFLAKE_ATTR_QUERY_ID);
```
both qid and sqid will return the same query id of `select 1`