### PR TITLE
fix build issue on github Windows

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -25,10 +25,10 @@ jobs:
   build_test_windows:
     strategy:
       matrix:
-        # have to specify minor version for 8.1 on windows
+        # have to specify minor version on windows
         # otherwise could get version mismatch issue when running test on github
         # need to keep track on the latest version
-        php-version: ['7.4', '8.0', '8.1.21', '8.2']
+        php-version: ['8.0.30', '8.1.23', '8.2.10']
     # The type of runner that the job will run on
     runs-on: windows-2019
     env:


### PR DESCRIPTION
Sometime we got build issue on Windows because PHP-8.4-dev was used instead of the PHP version we specified in test script.
Sounds like an issue with shivammathur/setup-php@v2 we used for setup PHP. Specify minor version could around this issue.

Also PHP 7.4 can't be built on github as it can't build with VS2019 and no previous VS versions available on github runners. Remove it from Windows build while still keep it on Linux/Mac. We should consider to remove 7.4 from support list though as it's end of life since 2022 Nov.