### PR TITLE
SNOW-1214750 clarify connection example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -356,6 +356,7 @@ The following example connects to the Snowflake database and performs a simple q
 Before using this example, set the :code:`$account`, :code:`$user`, and :code:`$password` variables to your account, login name,
 and password.
 The warehouse, database, schema parameters are optional, but can be specified to determine the context of the connection in which the query will be run.
+In this example, we'll use those too.
 
 .. code-block:: php
 
@@ -363,8 +364,11 @@ The warehouse, database, schema parameters are optional, but can be specified to
     $account = "<account_name>";
     $user = "<user_name>";
     $password = "<password>";
+    $warehouse = "<warehouse_name>";
+    $database = "<database_name>";
+    $schema = "<schema_name>";
 
-    $dbh = new PDO("snowflake:account=$account;warehouse=<wh_name>;database=<db_name>;schema=<schema_name>", $user, $password);
+    $dbh = new PDO("snowflake:account=$account;warehouse=$warehouse;database=$database;schema=$schema", $user, $password);
     $dbh->setAttribute( PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION );
     echo "Connected\n";
 


### PR DESCRIPTION
adding the optional warehouse, database, schema in the 'simple example' to demonstrate how to set the query context in the connection