### PR TITLE
SNOW-1333636: drop PHP 8.0 and add 8.3 support

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -29,7 +29,7 @@ jobs:
         # have to specify minor version on windows
         # otherwise could get version mismatch issue when running test on github
         # need to keep track on the latest version
-        php-version: ['8.0.30', '8.1.25', '8.2.12']
+        php-version: ['8.1.28', '8.2.18', '8.3.6']
     # The type of runner that the job will run on
     runs-on: windows-2019
     env:
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.0', '8.1', '8.2']
+        php-version: ['8.1', '8.2', '8.3']
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     env:
@@ -90,7 +90,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.0', '8.1', '8.2']
+        php-version: ['8.1', '8.2', '8.3']
     # The type of runner that the job will run on
     runs-on: macos-13
     env: 

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ To build the Snowflake PHP PDO Driver, the following software must be installed:
 
 To install and use the Snowflake PHP PDO Driver, you must have the following software installed:
 
-- PHP 8.2, 8.1 or 8.0 (Note: support for PHP 7.4 or lower is deprecated)
+- PHP 8.3, 8.2 or 8.1 (Note: support for PHP 8.0 or lower is deprecated)
 - the :code:`php-pdo` extension
 - the :code:`php-json` extension
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "snowflakedb/pdo_snowflake",
     "description": "PHP PDO driver for Snowflake",
     "require": {
-        "php": ">=7.4"
+        "php": ">=8.1"
     },
     "authors": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a501367f22460d5f4b4b8902388dcf2b",
+    "content-hash": "6cc28e1501d82c83cb4176b6d70235a1",
     "packages": [],
     "packages-dev": [],
     "aliases": [],
@@ -13,7 +13,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.4"
+        "php": ">=8.1"
     },
     "platform-dev": [],
     "plugin-api-version": "2.3.0"


### PR DESCRIPTION
Teamwork issue 928.
Would be a BCR as we drop support for PHP 8.0.