### PR TITLE
Add instructions in README to not to use a space-containing dir on Windows

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,6 +114,10 @@ To build the PHP driver for Windows:
        git clone https://github.com/snowflakedb/pdo_snowflake.git
        cd pdo_snowflake
 
+
+   **Choose a target directory where none of the subdirectories contain any spaces or special characters on the path.** E.g. :code:`C:\temp\pdo_snowflake`.
+   Without this, one of the setup scripts (`phpsdk-starter.bat`) will fail during step 4. 
+
 #. Run the script to download the PHP SDK:
 
    .. code-block:: batch


### PR DESCRIPTION
This is a document-only change.

Apparently the version of `php-sdk-binary-tools/phpsdk-starter.bat` what we use bails out with `<token> was unexpected at this time.` where `<token>`is the first string following the first space in the path to the script.
E.g. running the script from `C:\temp\directory **name** with spaces\pdo_snowflake\scripts` will yield '`**name**` was unexpected at this time'

Per issues found in the source repo on what we rely, this is known and indeed not supported.
So documenting it.