### PR TITLE
NO-SNOW change jira assignee, labels, priority

### DIFF
--- a/.github/workflows/jira_issue.yml
+++ b/.github/workflows/jira_issue.yml
@@ -37,7 +37,7 @@ jobs:
           summary: '${{ github.event.issue.title }}'
           description: |
             ${{ github.event.issue.body }} \\ \\ _Created from GitHub Action_ for ${{ github.event.issue.html_url }}
-          fields: '{ "customfield_11401": {"id": "14723"}, "assignee": {"id": "712020:3c0352b5-63f7-4e26-9afe-38f6f9f0f4c5"}, "components":[{"id":"19291"}] }'
+          fields: '{ "customfield_11401": {"id": "14723"}, "assignee": {"id": "712020:e1f41916-da57-4fe8-b317-116d5229aa51"}, "components":[{"id":"19291"}], "labels": ["oss"], "priority": {"id": "10001"} }'
 
       - name: Update GitHub Issue
         uses: ./jira/gajira-issue-update


### PR DESCRIPTION
### Description

No driver code was changed, issue is only affecting Jira creation workflow.

As discussed. Autogenerated jiras should now have a different base assignee and priority to match internal flows.
Also adding the label to reflect issue origin (oss).