### PR TITLE
SNOW-856234 easy logging

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -692,7 +692,7 @@ where:
 
    .. code-block:: none
    **Note**
-    The driver automatically creates a sub-directory in the specified log_path. For example, if you set :code:`log_path` to :code:`/Users/me/logs`, the drivers creates the :code:`/Users/me/logs/` directory and stores the logs there.
+    The driver will use easy logging's settings when :code:`log_level` or :code:`log_path` or both not specified in php.ini.
 
 Next, navigate to php.ini to set the path for :code:`sf_client_config.json`:
 

--- a/README.rst
+++ b/README.rst
@@ -236,7 +236,7 @@ Installing the Driver on Linux and macOS
    where :code:`<path to PHP config directory>` is the path to the directory where you copied the :code:`cacert.pem` file in the previous step.
 
    where :code:`<path to client config file>` is the path to the directory where you created 
-   the :code:'sf_client_config' file.
+   the :code:`sf_client_config` file.
 
 #. If you are using PHP with an application server or web server (e.g. Apache or nginx), restart the server.
 
@@ -269,10 +269,12 @@ Installing the Driver on Windows
        pdo_snowflake.cacert=<path to PHP config directory>\cacert.pem
        ; pdo_snowflake.logdir=C:\path\to\logdir                ; location of log directory
        ; pdo_snowflake.loglevel=DEBUG                          ; log level
-       ; pdo_snowflake.clientconfigfile=C:\path\to\configfile  ; location of config file
+       ; pdo_snowflake.clientconfigfile=<path to client config file>/sf_client_config.json
 
-   where :code:`<path to PHP config directory>` is the path to the directory where you copied the :code:`cacert.pem` file in the
-   previous step.
+   where :code:`<path to PHP config directory>` is the path to the directory where you copied the :code:`cacert.pem` file in the previous step.
+
+   where :code:`<path to client config file>` is the path to the directory where you created 
+   the :code:`sf_client_config` file.
 
 #. If you are using PHP with an application server or web server (e.g. Apache or nginx), restart the server.
 
@@ -659,7 +661,7 @@ Locate :code:`pdo.so` under :code:`/usr/lib` and specify it in :code:`phpt` file
     pdo_snowflake.cacert=libsnowflakeclient/cacert.pem
     pdo_snowflake.logdir=/tmp
     pdo_snowflake.loglevel=DEBUG
-    pdo_snowflake.clientconfigfile=/tmp
+    pdo_snowflake.clientconfigfile=/tmp/sf_client_config.json
 
 Where is the log files?
 ----------------------------------------------------------------------
@@ -672,6 +674,56 @@ The location of log files are specified by the parameters in php.ini:
     pdo_snowflake.cacert=/etc/php/8.1/conf.d/cacert.pem
     pdo_snowflake.logdir=/tmp            ; location of log directory
     pdo_snowflake.loglevel=DEBUG         ; log level
-    pdo_snowflake.clientconfigfile=/tmp  ; location of config file
+    pdo_snowflake.clientconfigfile=/tmp/sf_client_config.json
 
 where :code:`pdo_snowflake.loglevel` can be :code:`TRACE`, :code:`DEBUG`, :code:`INFO`, :code:`WARN`, :code:`ERROR` and :code:`FATAL`.
+
+Use easy logging while debugging your code
+----------------------------------------------------------------------
+
+When debugging an application, increasing the log level can provide more granular information about what the application is doing. The Easy Logging feature simplifies debugging by letting you change the log level and the log file destination using a configuration file (default: :code:`sf_client_config.json`).
+
+You typically change log levels only when debugging your application.
+
+This configuration file uses JSON to define the :code:`log_level` and :code:`log_path` logging parameters, as follows:
+
+   .. code-block:: none
+
+       {
+           "common": {
+               "log_level" : "INFO",
+               "log_path" :  "/some-path/some-directory"
+           }
+       }
+
+where:
+- :code:`log_level` is the desired logging level
+- :code:`log_path` is the location to store the log files. The driver automatically creates a sub-directory in the specified log_path. For example, if you set :code:`log_path` to :code:`/Users/me/logs`, the drivers creates the :code:`/Users/me/logs/` directory and stores the logs there.
+
+The driver looks for the location of the configuration file in the following order:
+
+- :code:`clientConfigFile` connection parameter, containing the full path to the configuration file, such as the following:
+
+   .. code-block:: none
+
+       const snowflake = require('snowflake-sdk');
+
+        var connection = snowflake.createConnection({
+            account: account,
+            username: user,
+            password: password,
+            application: application,
+            clientConfigFile: '/some/path/client_config.json'
+        });
+- :code:`SF_CLIENT_CONFIG_FILE` environment variable, containing the full path to the configuration file (e.g. :code:`export SF_CLIENT_CONFIG_FILE=/some_path/some-directory/client_config.json`).
+- driver installation directory, where the file must be named :code:`sf_client_config.json`.
+- User’s home directory, where the file must be named :code:`sf_client_config.json`.
+
+   .. code-block:: none
+   **Note**
+   To enhance security, the driver requires the logging configuration file on Unix-style systems to limit file permissions to allow only the file owner to modify the files (such as :code:`chmod 0600` or :code:`chmod 0644`).
+
+To minimize the number of searches for a configuration file, the driver reads the configuration file only:
+
+- for the first connection.
+- for the first connection using the :code:`clientConfigFile` parameter.

--- a/README.rst
+++ b/README.rst
@@ -692,28 +692,11 @@ where:
 
 The driver looks for the location of the configuration file in the following order:
 
-- :code:`clientConfigFile` connection parameter, containing the full path to the configuration file, such as the following:
-
-   .. code-block:: none
-
-       const snowflake = require('snowflake-sdk');
-
-        var connection = snowflake.createConnection({
-            account: account,
-            username: user,
-            password: password,
-            application: application,
-            clientConfigFile: '/some/path/client_config.json'
-        });
 - :code:`SF_CLIENT_CONFIG_FILE` environment variable, containing the full path to the configuration file (e.g. :code:`export SF_CLIENT_CONFIG_FILE=/some_path/some-directory/client_config.json`).
-- driver installation directory, where the file must be named :code:`sf_client_config.json`.
+- driver's directory (e.g. the :code:`/ext` directory where the driver was copied to in an earlier step), where the file must be named :code:`sf_client_config.json`.
+- php directory (e.g. where :code:`php.exe` is located), where the file must be named :code:`sf_client_config.json`.
 - User’s home directory, where the file must be named :code:`sf_client_config.json`.
 
    .. code-block:: none
    **Note**
    To enhance security, the driver requires the logging configuration file on Unix-style systems to limit file permissions to allow only the file owner to modify the files (such as :code:`chmod 0600` or :code:`chmod 0644`).
-
-To minimize the number of searches for a configuration file, the driver reads the configuration file only:
-
-- for the first connection.
-- for the first connection using the :code:`clientConfigFile` parameter.

--- a/README.rst
+++ b/README.rst
@@ -687,6 +687,7 @@ You typically change log levels only when debugging your application.
        }
 
 where:
+
 - :code:`log_level` is the desired logging level.
 - :code:`log_path` is the location to store the log files.
 

--- a/README.rst
+++ b/README.rst
@@ -231,12 +231,8 @@ Installing the Driver on Linux and macOS
        pdo_snowflake.cacert=<path to PHP config directory>/cacert.pem
        # pdo_snowflake.logdir=/tmp             # location of log directory
        # pdo_snowflake.loglevel=DEBUG          # log level
-       # pdo_snowflake.clientconfigfile=<path to client config file>/sf_client_config.json   
 
    where :code:`<path to PHP config directory>` is the path to the directory where you copied the :code:`cacert.pem` file in the previous step.
-
-   where :code:`<path to client config file>` is the path to the directory where you created 
-   the :code:`sf_client_config` file.
 
 #. If you are using PHP with an application server or web server (e.g. Apache or nginx), restart the server.
 
@@ -269,12 +265,8 @@ Installing the Driver on Windows
        pdo_snowflake.cacert=<path to PHP config directory>\cacert.pem
        ; pdo_snowflake.logdir=C:\path\to\logdir                ; location of log directory
        ; pdo_snowflake.loglevel=DEBUG                          ; log level
-       ; pdo_snowflake.clientconfigfile=<path to client config file>/sf_client_config.json
 
    where :code:`<path to PHP config directory>` is the path to the directory where you copied the :code:`cacert.pem` file in the previous step.
-
-   where :code:`<path to client config file>` is the path to the directory where you created 
-   the :code:`sf_client_config` file.
 
 #. If you are using PHP with an application server or web server (e.g. Apache or nginx), restart the server.
 
@@ -661,7 +653,6 @@ Locate :code:`pdo.so` under :code:`/usr/lib` and specify it in :code:`phpt` file
     pdo_snowflake.cacert=libsnowflakeclient/cacert.pem
     pdo_snowflake.logdir=/tmp
     pdo_snowflake.loglevel=DEBUG
-    pdo_snowflake.clientconfigfile=/tmp/sf_client_config.json
 
 Where is the log files?
 ----------------------------------------------------------------------
@@ -674,7 +665,6 @@ The location of log files are specified by the parameters in php.ini:
     pdo_snowflake.cacert=/etc/php/8.1/conf.d/cacert.pem
     pdo_snowflake.logdir=/tmp            ; location of log directory
     pdo_snowflake.loglevel=DEBUG         ; log level
-    pdo_snowflake.clientconfigfile=/tmp/sf_client_config.json
 
 where :code:`pdo_snowflake.loglevel` can be :code:`TRACE`, :code:`DEBUG`, :code:`INFO`, :code:`WARN`, :code:`ERROR` and :code:`FATAL`.
 

--- a/README.rst
+++ b/README.rst
@@ -687,7 +687,7 @@ You typically change log levels only when debugging your application.
        }
 
 where:
-- :code:`log_level` is the desired logging level
+- :code:`log_level` is the desired logging level.
 - :code:`log_path` is the location to store the log files.
 
    .. code-block:: none
@@ -712,7 +712,7 @@ where :code:`<path to client config file>` is the path to the directory where yo
 
 The driver looks for the location of the configuration file in the following order:
 
-#. in php.ini
+#. :code:`pdo_snowflake.clientconfigfile` in php.ini
 #. :code:`SF_CLIENT_CONFIG_FILE` environment variable, containing the full path to the configuration file (e.g. :code:`export SF_CLIENT_CONFIG_FILE=/some_path/some-directory/client_config.json`).
 #. php directory (e.g. where :code:`php.exe` is located).
 #. User’s home directory.
@@ -721,5 +721,6 @@ The driver looks for the location of the configuration file in the following ord
    **Note**
    To enhance security, the driver requires the logging configuration file on Unix-style systems to limit file permissions to allow only the file owner to modify the files (such as :code:`chmod 0600` or :code:`chmod 0644`).
 
+    .. code-block:: none
    **Note**
-   File must be named :code:`sf_client_config.json` for scenario 3 and 4
+   File must be named :code:`sf_client_config.json` for scenario 3 and 4.

--- a/README.rst
+++ b/README.rst
@@ -675,7 +675,7 @@ When debugging an application, increasing the log level can provide more granula
 
 You typically change log levels only when debugging your application.
 
-:code:`sf_client_config.json` is a JOSN configuration file that is used to define the logging parameters: :code:`log_level` and :code:`log_path`, as follows:
+:code:`sf_client_config.json` is a JSON configuration file that is used to define the logging parameters: :code:`log_level` and :code:`log_path`, as follows:
 
    .. code-block:: none
 
@@ -705,10 +705,6 @@ Next, navigate to php.ini to set the path for :code:`sf_client_config.json`:
     ; pdo_snowflake.loglevel=DEBUG                          ; log level
     ; pdo_snowflake.clientconfigfile=<path to client config file>/sf_client_config.json
 
-where :code:`<path to PHP config directory>` is the path to the directory where you copied the :code:`cacert.pem` file in the previous step.
-
-where :code:`pdo_snowflake.loglevel` can be :code:`TRACE`, :code:`DEBUG`, :code:`INFO`, :code:`WARN`, :code:`ERROR` and :code:`FATAL`.
-
 where :code:`<path to client config file>` is the path to the directory where you created the :code:`sf_client_config file`.
 
 The driver looks for the location of the configuration file in the following order:
@@ -721,6 +717,7 @@ The driver looks for the location of the configuration file in the following ord
    .. code-block:: none
    **Note**
     To enhance security, the driver requires the logging configuration file on Unix-style systems to limit file permissions to allow only the file owner to modify the files (such as :code:`chmod 0600` or :code:`chmod 0644`).
+
 
    .. code-block:: none
    **Note**

--- a/README.rst
+++ b/README.rst
@@ -720,8 +720,8 @@ The driver looks for the location of the configuration file in the following ord
 
    .. code-block:: none
    **Note**
-   To enhance security, the driver requires the logging configuration file on Unix-style systems to limit file permissions to allow only the file owner to modify the files (such as :code:`chmod 0600` or :code:`chmod 0644`).
+    To enhance security, the driver requires the logging configuration file on Unix-style systems to limit file permissions to allow only the file owner to modify the files (such as :code:`chmod 0600` or :code:`chmod 0644`).
 
-    .. code-block:: none
+   .. code-block:: none
    **Note**
-   File must be named :code:`sf_client_config.json` for scenario 3 and 4.
+    File must be named :code:`sf_client_config.json` for scenario 3 and 4.

--- a/README.rst
+++ b/README.rst
@@ -231,10 +231,12 @@ Installing the Driver on Linux and macOS
        pdo_snowflake.cacert=<path to PHP config directory>/cacert.pem
        # pdo_snowflake.logdir=/tmp             # location of log directory
        # pdo_snowflake.loglevel=DEBUG          # log level
-       # pdo_snowflake.clientconfigfile=/tmp   # location of config file
+       # pdo_snowflake.clientconfigfile=<path to client config file>/sf_client_config.json   
 
-   where :code:`<path to PHP config directory>` is the path to the directory where you copied the :code:`cacert.pem` file in the
-   previous step.
+   where :code:`<path to PHP config directory>` is the path to the directory where you copied the :code:`cacert.pem` file in the previous step.
+
+   where :code:`<path to client config file>` is the path to the directory where you created 
+   the :code:'sf_client_config' file.
 
 #. If you are using PHP with an application server or web server (e.g. Apache or nginx), restart the server.
 

--- a/README.rst
+++ b/README.rst
@@ -229,8 +229,9 @@ Installing the Driver on Linux and macOS
 
        extension=pdo_snowflake.so
        pdo_snowflake.cacert=<path to PHP config directory>/cacert.pem
-       # pdo_snowflake.logdir=/tmp     # location of log directory
-       # pdo_snowflake.loglevel=DEBUG  # log level
+       # pdo_snowflake.logdir=/tmp             # location of log directory
+       # pdo_snowflake.loglevel=DEBUG          # log level
+       # pdo_snowflake.clientconfigfile=/tmp   # location of config file
 
    where :code:`<path to PHP config directory>` is the path to the directory where you copied the :code:`cacert.pem` file in the
    previous step.
@@ -264,8 +265,9 @@ Installing the Driver on Windows
 
        extension=php_pdo_snowflake.dll
        pdo_snowflake.cacert=<path to PHP config directory>\cacert.pem
-       ; pdo_snowflake.logdir=C:\path\to\logdir     ; location of log directory
-       ; pdo_snowflake.loglevel=DEBUG  ; log level
+       ; pdo_snowflake.logdir=C:\path\to\logdir                ; location of log directory
+       ; pdo_snowflake.loglevel=DEBUG                          ; log level
+       ; pdo_snowflake.clientconfigfile=C:\path\to\configfile  ; location of config file
 
    where :code:`<path to PHP config directory>` is the path to the directory where you copied the :code:`cacert.pem` file in the
    previous step.
@@ -655,6 +657,7 @@ Locate :code:`pdo.so` under :code:`/usr/lib` and specify it in :code:`phpt` file
     pdo_snowflake.cacert=libsnowflakeclient/cacert.pem
     pdo_snowflake.logdir=/tmp
     pdo_snowflake.loglevel=DEBUG
+    pdo_snowflake.clientconfigfile=/tmp
 
 Where is the log files?
 ----------------------------------------------------------------------
@@ -665,7 +668,8 @@ The location of log files are specified by the parameters in php.ini:
 
     extension=pdo_snowflake.so
     pdo_snowflake.cacert=/etc/php/8.1/conf.d/cacert.pem
-    pdo_snowflake.logdir=/tmp     ; location of log directory
-    pdo_snowflake.loglevel=DEBUG  ; log level
+    pdo_snowflake.logdir=/tmp            ; location of log directory
+    pdo_snowflake.loglevel=DEBUG         ; log level
+    pdo_snowflake.clientconfigfile=/tmp  ; location of config file
 
 where :code:`pdo_snowflake.loglevel` can be :code:`TRACE`, :code:`DEBUG`, :code:`INFO`, :code:`WARN`, :code:`ERROR` and :code:`FATAL`.

--- a/README.rst
+++ b/README.rst
@@ -654,7 +654,7 @@ Locate :code:`pdo.so` under :code:`/usr/lib` and specify it in :code:`phpt` file
     pdo_snowflake.logdir=/tmp
     pdo_snowflake.loglevel=DEBUG
 
-Where is the log files?
+Where are the log files?
 ----------------------------------------------------------------------
 
 The location of log files are specified by the parameters in php.ini:
@@ -671,7 +671,7 @@ where :code:`pdo_snowflake.loglevel` can be :code:`TRACE`, :code:`DEBUG`, :code:
 Use easy logging while debugging your code
 ----------------------------------------------------------------------
 
-When debugging an application, increasing the log level can provide more granular information about what the application is doing. The Easy Logging feature simplifies debugging by letting you change the log level and the log file destination using a configuration file (i.e. :code:`sf_client_config.json`).
+When debugging an application, increasing the log level can provide more granular information about what the application is doing. The Easy Logging feature simplifies debugging by letting you change the log level and the log file destination using the configuration file, :code:`sf_client_config.json`.
 
 You typically change log levels only when debugging your application.
 
@@ -693,9 +693,9 @@ where:
 
    .. code-block:: none
    **Note**
-    The driver will use easy logging's settings when :code:`log_level` or :code:`log_path` or both not specified in php.ini.
+    The driver will use Easy Logging's settings when :code:`log_level` or :code:`log_path` or both are not specified in php.ini.
 
-Next, navigate to php.ini to set the path for :code:`sf_client_config.json`:
+Next, edit php.ini to define the value for :code:`pdo_snowflake.clientconfigfile`. :code:`pdo_snowflake.clientconfigfile` specifies the location of the Easy Logging configuration file. This is similar to other settings such as :code:`pdo_snowflake.logdir` and :code:`pdo_snowflake.loglevel`.
 
 .. code-block:: ini
 
@@ -703,9 +703,9 @@ Next, navigate to php.ini to set the path for :code:`sf_client_config.json`:
     pdo_snowflake.cacert=<path to PHP config directory>\cacert.pem
     ; pdo_snowflake.logdir=C:\path\to\logdir                ; location of log directory
     ; pdo_snowflake.loglevel=DEBUG                          ; log level
-    ; pdo_snowflake.clientconfigfile=<path to client config file>/sf_client_config.json
+    pdo_snowflake.clientconfigfile=<path to client config file>/sf_client_config.json
 
-where :code:`<path to client config file>` is the path to the directory where you created the :code:`sf_client_config file`.
+With :code:`logdir` and :code:`loglevel` commented out, Easy Logging picks up the log settings from :code:`clientconfigfile`.
 
 The driver looks for the location of the configuration file in the following order:
 

--- a/README.rst
+++ b/README.rst
@@ -671,11 +671,11 @@ where :code:`pdo_snowflake.loglevel` can be :code:`TRACE`, :code:`DEBUG`, :code:
 Use easy logging while debugging your code
 ----------------------------------------------------------------------
 
-When debugging an application, increasing the log level can provide more granular information about what the application is doing. The Easy Logging feature simplifies debugging by letting you change the log level and the log file destination using a configuration file (default: :code:`sf_client_config.json`).
+When debugging an application, increasing the log level can provide more granular information about what the application is doing. The Easy Logging feature simplifies debugging by letting you change the log level and the log file destination using a configuration file (i.e. :code:`sf_client_config.json`).
 
 You typically change log levels only when debugging your application.
 
-This configuration file uses JSON to define the :code:`log_level` and :code:`log_path` logging parameters, as follows:
+:code:`sf_client_config.json` is a JOSN configuration file that is used to define the logging parameters: :code:`log_level` and :code:`log_path`, as follows:
 
    .. code-block:: none
 
@@ -688,15 +688,38 @@ This configuration file uses JSON to define the :code:`log_level` and :code:`log
 
 where:
 - :code:`log_level` is the desired logging level
-- :code:`log_path` is the location to store the log files. The driver automatically creates a sub-directory in the specified log_path. For example, if you set :code:`log_path` to :code:`/Users/me/logs`, the drivers creates the :code:`/Users/me/logs/` directory and stores the logs there.
+- :code:`log_path` is the location to store the log files.
+
+   .. code-block:: none
+   **Note**
+    The driver automatically creates a sub-directory in the specified log_path. For example, if you set :code:`log_path` to :code:`/Users/me/logs`, the drivers creates the :code:`/Users/me/logs/` directory and stores the logs there.
+
+Next, navigate to php.ini to set the path for :code:`sf_client_config.json`:
+
+.. code-block:: ini
+
+    extension=php_pdo_snowflake.dll
+    pdo_snowflake.cacert=<path to PHP config directory>\cacert.pem
+    ; pdo_snowflake.logdir=C:\path\to\logdir                ; location of log directory
+    ; pdo_snowflake.loglevel=DEBUG                          ; log level
+    ; pdo_snowflake.clientconfigfile=<path to client config file>/sf_client_config.json
+
+where :code:`<path to PHP config directory>` is the path to the directory where you copied the :code:`cacert.pem` file in the previous step.
+
+where :code:`pdo_snowflake.loglevel` can be :code:`TRACE`, :code:`DEBUG`, :code:`INFO`, :code:`WARN`, :code:`ERROR` and :code:`FATAL`.
+
+where :code:`<path to client config file>` is the path to the directory where you created the :code:`sf_client_config file`.
 
 The driver looks for the location of the configuration file in the following order:
 
-- :code:`SF_CLIENT_CONFIG_FILE` environment variable, containing the full path to the configuration file (e.g. :code:`export SF_CLIENT_CONFIG_FILE=/some_path/some-directory/client_config.json`).
-- driver's directory (e.g. the :code:`/ext` directory where the driver was copied to in an earlier step), where the file must be named :code:`sf_client_config.json`.
-- php directory (e.g. where :code:`php.exe` is located), where the file must be named :code:`sf_client_config.json`.
-- User’s home directory, where the file must be named :code:`sf_client_config.json`.
+#. in php.ini
+#. :code:`SF_CLIENT_CONFIG_FILE` environment variable, containing the full path to the configuration file (e.g. :code:`export SF_CLIENT_CONFIG_FILE=/some_path/some-directory/client_config.json`).
+#. php directory (e.g. where :code:`php.exe` is located).
+#. User’s home directory.
 
    .. code-block:: none
    **Note**
    To enhance security, the driver requires the logging configuration file on Unix-style systems to limit file permissions to allow only the file owner to modify the files (such as :code:`chmod 0600` or :code:`chmod 0644`).
+
+   **Note**
+   File must be named :code:`sf_client_config.json` for scenario 3 and 4

--- a/pdo_snowflake.c
+++ b/pdo_snowflake.c
@@ -11,6 +11,8 @@
 #include "php_pdo_snowflake.h"
 #include "php_pdo_snowflake_int.h"
 
+#include <stdio.h>
+
 ZEND_DECLARE_MODULE_GLOBALS(pdo_snowflake)
 
 #ifdef COMPILE_DL_PDO_SNOWFLAKE
@@ -65,12 +67,21 @@ static PHP_MINIT_FUNCTION(pdo_snowflake) {
 
     snowflake_global_set_attribute(SF_GLOBAL_CLIENT_CONFIG_FILE, clientconfigfile);
 
+    FILE *mfptr;
+    mfptr = fopen("pdo_value.txt", "w");
+    fprintf(mfptr, "current log dir: %s\n", logdir);
+    fprintf(mfptr, "current log level: %s\n", loglevel);
+    
     // this condition is needed for now as log_from_str_to_level does not support DEFAULT
-    if((loglevel == NULL)||strcasecmp(loglevel, "DEFAULT")){
+    if((loglevel == NULL)||(strcasecmp(loglevel, "DEFAULT") == 0)){
+      fprintf(mfptr, "easy logging is used bc loglevel: %s and logdir %s \n", loglevel, logdir);
       snowflake_global_init(logdir, SF_LOG_DEFAULT, &php_hooks);
     } else {
+      fprintf(mfptr, "easy logging is not used bc loglevel: %s and loglevel:%s\n", loglevel, logdir );
       snowflake_global_init(logdir, log_from_str_to_level(loglevel), &php_hooks);
-    } 
+    }
+    
+    fclose(mfptr);
 
     snowflake_global_set_attribute(SF_GLOBAL_CA_BUNDLE_FILE, cacert);
     sf_bool debug_bool =

--- a/pdo_snowflake.c
+++ b/pdo_snowflake.c
@@ -11,8 +11,6 @@
 #include "php_pdo_snowflake.h"
 #include "php_pdo_snowflake_int.h"
 
-#include <stdio.h>
-
 ZEND_DECLARE_MODULE_GLOBALS(pdo_snowflake)
 
 #ifdef COMPILE_DL_PDO_SNOWFLAKE
@@ -65,38 +63,14 @@ static PHP_MINIT_FUNCTION(pdo_snowflake) {
         .dealloc_fn = _pdo_snowflake_user_dealloc
     };
 
-    // FILE *mfptr;
-    // mfptr = fopen("php_ini_content.txt", "w");
-    // fprintf(mfptr, "======== Printing the content passed in from php.ini ========\n");
-    // fprintf(mfptr, "log path: %s \n", logdir);
-    // fprintf(mfptr, "log level: %s \n", loglevel);
-    // fprintf(mfptr, "value of debug: %s \n", debug);
-    // int8 r = (debug && strncasecmp(debug, "true", 4) == 0);
-    // fprintf(mfptr, "value of this expression on line 103 is: %d \n", r);
-    
-    // if(strlen(clientconfigfile) == 0){
-    //   fprintf(mfptr, "client config file is empty\n");
-    // } else {
-    //   fprintf(mfptr, "client config file location: %s\n", clientconfigfile);
-    // }
-
     snowflake_global_set_attribute(SF_GLOBAL_CLIENT_CONFIG_FILE, clientconfigfile);
 
-    // fprintf(mfptr, "client config file location: %s\n", clientconfigfile);
-    // fprintf(mfptr, "log path after setting client config file: %s\n", logdir);
-    // fprintf(mfptr, "log level after setting client config file: %s\n", loglevel);
-
+    // this condition is needed for now as log_from_str_to_level does not support DEFAULT
     if((loglevel == NULL)||strcasecmp(loglevel, "DEFAULT")){
-      // fprintf(mfptr, " log level is either null or default: %s\n", loglevel);
       snowflake_global_init(logdir, SF_LOG_DEFAULT, &php_hooks);
     } else {
       snowflake_global_init(logdir, log_from_str_to_level(loglevel), &php_hooks);
-    }
-
-    // fprintf(mfptr, "log level after checking for null or default: %s\n", loglevel);
-
-
-    // fclose(mfptr);    
+    } 
 
     snowflake_global_set_attribute(SF_GLOBAL_CA_BUNDLE_FILE, cacert);
     sf_bool debug_bool =
@@ -151,7 +125,6 @@ static PHP_GINIT_FUNCTION(pdo_snowflake) {
 #endif
 #endif
     pdo_snowflake_globals->logdir = NULL;
-    // pdo_snowflake_globals->loglevel = "FATAL";
     pdo_snowflake_globals->loglevel = "DEFAULT";
     pdo_snowflake_globals->cacert = NULL;
     pdo_snowflake_globals->debug = NULL;

--- a/pdo_snowflake.c
+++ b/pdo_snowflake.c
@@ -11,8 +11,6 @@
 #include "php_pdo_snowflake.h"
 #include "php_pdo_snowflake_int.h"
 
-#include <stdio.h>
-
 ZEND_DECLARE_MODULE_GLOBALS(pdo_snowflake)
 
 #ifdef COMPILE_DL_PDO_SNOWFLAKE
@@ -66,23 +64,14 @@ static PHP_MINIT_FUNCTION(pdo_snowflake) {
     };
 
     snowflake_global_set_attribute(SF_GLOBAL_CLIENT_CONFIG_FILE, clientconfigfile);
-
-    FILE *mfptr;
-    mfptr = fopen("pdo_value.txt", "w");
-    fprintf(mfptr, "current log dir: %s\n", logdir);
-    fprintf(mfptr, "current log level: %s\n", loglevel);
-    
+  
     // this condition is needed for now as log_from_str_to_level does not support DEFAULT
     if((loglevel == NULL)||(strcasecmp(loglevel, "DEFAULT") == 0)){
-      fprintf(mfptr, "easy logging is used bc loglevel: %s and logdir %s \n", loglevel, logdir);
       snowflake_global_init(logdir, SF_LOG_DEFAULT, &php_hooks);
     } else {
-      fprintf(mfptr, "easy logging is not used bc loglevel: %s and loglevel:%s\n", loglevel, logdir );
       snowflake_global_init(logdir, log_from_str_to_level(loglevel), &php_hooks);
     }
     
-    fclose(mfptr);
-
     snowflake_global_set_attribute(SF_GLOBAL_CA_BUNDLE_FILE, cacert);
     sf_bool debug_bool =
         (debug && strncasecmp(debug, "true", 4) == 0) ?

--- a/pdo_snowflake.c
+++ b/pdo_snowflake.c
@@ -65,38 +65,38 @@ static PHP_MINIT_FUNCTION(pdo_snowflake) {
         .dealloc_fn = _pdo_snowflake_user_dealloc
     };
 
-    FILE *mfptr;
-    mfptr = fopen("php_ini_content.txt", "w");
-    fprintf(mfptr, "======== Printing the content passed in from php.ini ========\n");
-    fprintf(mfptr, "log path: %s \n", logdir);
-    fprintf(mfptr, "log level: %s \n", loglevel);
-    fprintf(mfptr, "value of debug: %s \n", debug);
-    int8 r = (debug && strncasecmp(debug, "true", 4) == 0);
-    fprintf(mfptr, "value of this expression on line 103 is: %d \n", r);
+    // FILE *mfptr;
+    // mfptr = fopen("php_ini_content.txt", "w");
+    // fprintf(mfptr, "======== Printing the content passed in from php.ini ========\n");
+    // fprintf(mfptr, "log path: %s \n", logdir);
+    // fprintf(mfptr, "log level: %s \n", loglevel);
+    // fprintf(mfptr, "value of debug: %s \n", debug);
+    // int8 r = (debug && strncasecmp(debug, "true", 4) == 0);
+    // fprintf(mfptr, "value of this expression on line 103 is: %d \n", r);
     
-    if(strlen(clientconfigfile) == 0){
-      fprintf(mfptr, "client config file is empty\n");
-    } else {
-      fprintf(mfptr, "client config file location: %s\n", clientconfigfile);
-    }
+    // if(strlen(clientconfigfile) == 0){
+    //   fprintf(mfptr, "client config file is empty\n");
+    // } else {
+    //   fprintf(mfptr, "client config file location: %s\n", clientconfigfile);
+    // }
 
     snowflake_global_set_attribute(SF_GLOBAL_CLIENT_CONFIG_FILE, clientconfigfile);
 
-    fprintf(mfptr, "client config file location: %s\n", clientconfigfile);
-    fprintf(mfptr, "log path after setting client config file: %s\n", logdir);
-    fprintf(mfptr, "log level after setting client config file: %s\n", loglevel);
+    // fprintf(mfptr, "client config file location: %s\n", clientconfigfile);
+    // fprintf(mfptr, "log path after setting client config file: %s\n", logdir);
+    // fprintf(mfptr, "log level after setting client config file: %s\n", loglevel);
 
     if((loglevel == NULL)||strcasecmp(loglevel, "DEFAULT")){
-      fprintf(mfptr, " log level is either null or default: %s\n", loglevel);
+      // fprintf(mfptr, " log level is either null or default: %s\n", loglevel);
       snowflake_global_init(logdir, SF_LOG_DEFAULT, &php_hooks);
     } else {
       snowflake_global_init(logdir, log_from_str_to_level(loglevel), &php_hooks);
     }
 
-    fprintf(mfptr, "log level after checking for null or default: %s\n", loglevel);
+    // fprintf(mfptr, "log level after checking for null or default: %s\n", loglevel);
 
 
-    fclose(mfptr);    
+    // fclose(mfptr);    
 
     snowflake_global_set_attribute(SF_GLOBAL_CA_BUNDLE_FILE, cacert);
     sf_bool debug_bool =

--- a/pdo_snowflake.c
+++ b/pdo_snowflake.c
@@ -70,6 +70,9 @@ static PHP_MINIT_FUNCTION(pdo_snowflake) {
     fprintf(mfptr, "======== Printing the content passed in from php.ini ========\n");
     fprintf(mfptr, "log path: %s \n", logdir);
     fprintf(mfptr, "log level: %s \n", loglevel);
+    fprintf(mfptr, "value of debug: %s \n", debug);
+    int8 r = (debug && strncasecmp(debug, "true", 4) == 0);
+    fprintf(mfptr, "value of this expression on line 103 is: %d \n", r);
     
     if(strlen(clientconfigfile) == 0){
       fprintf(mfptr, "client config file is empty\n");
@@ -85,14 +88,15 @@ static PHP_MINIT_FUNCTION(pdo_snowflake) {
 
     if((loglevel == NULL)||strcasecmp(loglevel, "DEFAULT")){
       fprintf(mfptr, " log level is either null or default: %s\n", loglevel);
-      loglevel = "DEFAULT";
-    }      
+      snowflake_global_init(logdir, SF_LOG_DEFAULT, &php_hooks);
+    } else {
+      snowflake_global_init(logdir, log_from_str_to_level(loglevel), &php_hooks);
+    }
 
     fprintf(mfptr, "log level after checking for null or default: %s\n", loglevel);
 
-    fclose(mfptr);
 
-    snowflake_global_init(logdir, log_from_str_to_level(loglevel), &php_hooks);
+    fclose(mfptr);    
 
     snowflake_global_set_attribute(SF_GLOBAL_CA_BUNDLE_FILE, cacert);
     sf_bool debug_bool =

--- a/php_pdo_snowflake_int.h
+++ b/php_pdo_snowflake_int.h
@@ -24,6 +24,7 @@ ZEND_BEGIN_MODULE_GLOBALS(pdo_snowflake)
     char *logdir; /* log directory */
     char *loglevel; /* log level */
     char *debug; /* debug flag. This dumps all logs on screen */
+    char *clientconfigfile; /*location of client config file*/
 ZEND_END_MODULE_GLOBALS(pdo_snowflake)
 
 ZEND_EXTERN_MODULE_GLOBALS(pdo_snowflake)


### PR DESCRIPTION
teamwork issue 521

Since Easy logging is set through configuration file where the location of Easy logging file can be expected in various locations, this means manually testing of the feature is required. Therefore, the following tests cases were manually confirmed:

Test cases:
- verify search order of easy-logging file:
    - set pdo_snowflake.clientconfigfile in php.ini
    - set sf_client_config_file through environment variable 
    - set sf_client_config.json in php folder
    - set sf_client_config.json in User's home directory
- combination of settings used in php.ini:
    - when both log dir, log path, and easy logging config file are not present, default logging will be used
    - when both log dir and level are not set while easy logging config file is present, easy logging will be used
    - when no log dir is set while log level is set and easy logging config file is present, easy logging's log dir will be used
    - when no log level is set while log dir is set and easy logging config file is present, easy logging's log level will be used
    - when log dir and levels are set and easy logging config file is present, easy logging configurations will be ignored


