### PR TITLE
SNOW-2855381: Remove PHP version prefix for the reported PDO version

### DIFF
--- a/tests/crud.phpt
+++ b/tests/crud.phpt
@@ -117,7 +117,7 @@ deleted rows: 1
 inserted rows: 1
 inserted rows: 1
 name: C1, native_type: FIXED, len: 0, precision: 38, scale: 0
-name: C2, native_type: TEXT, len: 134217728, precision: 0, scale: 0
+name: C2, native_type: TEXT, len: 16777216, precision: 0, scale: 0
 1 test1
 3 test101
 11 test111

--- a/tests/selectbin.phpt
+++ b/tests/selectbin.phpt
@@ -89,7 +89,7 @@ pdo_snowflake.cacert=libsnowflakeclient/cacert.pem
 --EXPECT--
 Connected to Snowflake
 name: C1, native_type: FIXED, scale: 0, precision: 38, len: 0
-name: C2, native_type: BINARY, scale: 0, precision: 0, len: 67108864
+name: C2, native_type: BINARY, scale: 0, precision: 0, len: 8388608
 Results in String
 C1: 1, C2: 1234,5678,65,66
 C1: 2, C2: abcd,def0,67,68


### PR DESCRIPTION
The plan is to move the PHP version into `client_environment`, however that requires a creation of `libsnowflakeclient` interface that would allow to inject the `client_environment` field.