### PR TITLE
NO-SNOW fix jira creation + closure workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -4,12 +4,8 @@ about: Something isn't working as expected? Here is the right place to report.
 labels: bug
 ---
 
-
-<!--
-If you need urgent assistance then file the issue using the support process: 
-https://community.snowflake.com/s/article/How-To-Submit-a-Support-Case-in-Snowflake-Lodge 
-otherwise continue here. 
--->
+:exclamation: If you need **urgent assistance** then [file a case with Snowflake Support](https://community.snowflake.com/s/article/How-To-Submit-a-Support-Case-in-Snowflake-Lodge).
+Otherwise continue here.
 
 
 Please answer these questions before submitting your issue. 

--- a/.github/workflows/jira_close.yml
+++ b/.github/workflows/jira_close.yml
@@ -8,28 +8,40 @@ jobs:
   close-issue:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          repository: snowflakedb/gh-actions
-          ref: jira_v1
-          token: ${{ secrets.SNOWFLAKE_GITHUB_TOKEN }} # stored in GitHub secrets
-          path: .
-      - name: Jira login
-        uses: atlassian/gajira-login@master
-        env:
-          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
-          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
-          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
       - name: Extract issue from title
         id: extract
         env:
-          TITLE: "${{ github.event.issue.title }}"
+          TITLE: '${{ github.event.issue.title }}'
         run: |
           jira=$(echo -n $TITLE | awk '{print $1}' | sed -e 's/://')
           echo ::set-output name=jira::$jira
-      - name: Close issue
-        uses: ./jira/gajira-close
+
+      - name: Close Jira Issue
         if: startsWith(steps.extract.outputs.jira, 'SNOW-')
-        with:
-          issue: "${{ steps.extract.outputs.jira }}"
+        env:
+          ISSUE_KEY: ${{ steps.extract.outputs.jira }}
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+        run: |
+          JIRA_API_URL="${JIRA_BASE_URL}/rest/api/2/issue/${ISSUE_KEY}/transitions"
+
+          curl -X POST \
+            --url "$JIRA_API_URL" \
+            --user "${JIRA_USER_EMAIL}:${JIRA_API_TOKEN}" \
+            --header "Content-Type: application/json" \
+            --data "{
+              \"update\": {
+                \"comment\": [
+                  { \"add\": { \"body\": \"Closed on GitHub\" } }
+                ]
+              },
+              \"fields\": {
+                \"customfield_12860\": { \"id\": \"11506\" },
+                \"customfield_10800\": { \"id\": \"-1\" },
+                \"customfield_12500\": { \"id\": \"11302\" },
+                \"customfield_12400\": { \"id\": \"-1\" },
+                \"resolution\": { \"name\": \"Done\" }
+              },
+              \"transition\": { \"id\": \"71\" }
+            }"

--- a/.github/workflows/jira_issue.yml
+++ b/.github/workflows/jira_issue.yml
@@ -13,38 +13,92 @@ jobs:
       issues: write
     if: ((github.event_name == 'issue_comment' && github.event.comment.body == 'recreate jira' && github.event.comment.user.login == 'sfc-gh-mkeller') || (github.event_name == 'issues' && github.event.pull_request.user.login != 'whitesource-for-github-com[bot]'))
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          repository: snowflakedb/gh-actions
-          ref: jira_v1
-          token: ${{ secrets.SNOWFLAKE_GITHUB_TOKEN }} # stored in GitHub secrets
-          path: .
-
-      - name: Login
-        uses: atlassian/gajira-login@v2.0.0
+      - name: Create JIRA Ticket
+        id: create
         env:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
           JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+        run: |
+          # debug
+          #set -x
+          TMP_BODY=$(mktemp)
+          trap "rm -f $TMP_BODY" EXIT
 
-      - name: Create JIRA Ticket
-        id: create
-        uses: atlassian/gajira-create@v2.0.1
-        with:
-          project: SNOW
-          issuetype: Bug
-          summary: '${{ github.event.issue.title }}'
-          description: |
-            ${{ github.event.issue.body }} \\ \\ _Created from GitHub Action_ for ${{ github.event.issue.html_url }}
-          fields: '{ "customfield_11401": {"id": "14723"}, "assignee": {"id": "712020:e527ae71-55cc-4e02-9217-1ca4ca8028a2"}, "components":[{"id":"19291"}], "labels": ["oss"], "priority": {"id": "10001"} }'
+          # Escape special characters in title and body
+          TITLE=$(echo "${ISSUE_TITLE//`/\\`}" | sed 's/"/\\"/g' | sed "s/'/\\\'/g")
+          echo "${ISSUE_BODY//`/\\`}" | sed 's/"/\\"/g' | sed "s/'/\\\'/g" > $TMP_BODY
+          echo -e "\n\n_Created from GitHub Action_ for $ISSUE_URL" >> $TMP_BODY
+          BODY=$(cat "$TMP_BODY")
+
+          PAYLOAD=$(jq -n \
+          --arg issuetitle "$TITLE" \
+          --arg issuebody "$BODY" \
+          '{
+            fields: {
+              project: { key: "SNOW" },
+              issuetype: { name: "Bug" },
+              summary: $issuetitle,
+              description: $issuebody,
+              customfield_11401: { id: "14723" },
+              assignee: { id: "712020:e527ae71-55cc-4e02-9217-1ca4ca8028a2" },
+              components: [{ id: "19291" }],
+              labels: ["oss"],
+              priority: { id: "10001" }
+            }
+          }')
+
+          # Create JIRA issue using REST API
+          RESPONSE=$(curl -s -X POST \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/json" \
+            -u "$JIRA_USER_EMAIL:$JIRA_API_TOKEN" \
+            "$JIRA_BASE_URL/rest/api/2/issue" \
+            -d "$PAYLOAD")
+
+          # Extract JIRA issue key from response
+          JIRA_KEY=$(echo "$RESPONSE" | jq -r '.key')
+
+          if [ "$JIRA_KEY" = "null" ] || [ -z "$JIRA_KEY" ]; then
+            echo "Failed to create JIRA issue"
+            echo "Response: $RESPONSE"
+            echo "Request payload: $PAYLOAD"
+            exit 1
+          fi
+
+          echo "Created JIRA issue: $JIRA_KEY"
+          echo "jira_key=$JIRA_KEY" >> $GITHUB_OUTPUT
 
       - name: Update GitHub Issue
-        uses: ./jira/gajira-issue-update
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          issue_number: "{{ event.issue.id }}"
-          owner: "{{ event.repository.owner.login }}"
-          name: "{{ event.repository.name }}"
-          jira: "${{ steps.create.outputs.issue }}"
+          REPOSITORY: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          JIRA_KEY: ${{ steps.create.outputs.jira_key }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+        run: |
+          TITLE=$(echo "${ISSUE_TITLE//`/\\`}" | sed 's/"/\\"/g' | sed "s/'/\\\'/g")
+          PAYLOAD=$(jq -n \
+          --arg issuetitle "$TITLE" \
+          --arg jirakey "$JIRA_KEY" \
+          '{
+            title: ($jirakey + ": " + $issuetitle)
+          }')
+
+          # Update Github issue title with jira id
+          curl -s \
+            -X PATCH \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/$REPOSITORY/issues/$ISSUE_NUMBER" \
+            -d "$PAYLOAD"
+
+          if [ "$?" != 0 ]; then
+            echo "Failed to update GH issue. Payload was:"
+            echo "$PAYLOAD"
+            exit 1
+          fi


### PR DESCRIPTION
Description
No code was changed.

Couple days/weeks back Jira issue creation/closure workflows seem to be broken across all the Snowflake driver repositories, leaving this integration and the associated workflows, crippled.

Very recently it was fixed in Python driver repo thus would like to apply a similar fix here too.
As an extra step, uniformize the notification of 'please create a case if its urgent' message in issue template, across all driver repos.