### PR TITLE
Fix Windows build error: unresolved `if_nametoindex` symbol

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -18,6 +18,7 @@ if (PHP_PDO_SNOWFLAKE != "no") {
             CHECK_LIB('aws-checksums.lib', 'pdo_snowflake') && CHECK_LIB('aws-c-cal.lib', 'pdo_snowflake') && CHECK_LIB('aws-c-event-stream.lib', 'pdo_snowflake') &&
             CHECK_LIB('aws-c-sdkutils.lib', 'pdo_snowflake') && CHECK_LIB('aws-c-io.lib', 'pdo_snowflake') && CHECK_LIB('aws-c-common.lib', 'pdo_snowflake') &&
             CHECK_LIB('azure-storage-lite.lib', 'pdo_snowflake') &&
+            CHECK_LIB('iphlpapi.lib', 'pdo_snowflake') &&
             CHECK_LIB('Userenv.lib', 'pdo_snowflake') && CHECK_LIB('Version.lib', 'pdo_snowflake') && CHECK_LIB('Secur32.lib', 'pdo_snowflake') &&
             CHECK_LIB('Ncrypt.lib', 'pdo_snowflake') && CHECK_LIB('Shlwapi.lib', 'pdo_snowflake') &&
             CHECK_HEADER_ADD_INCLUDE('snowflake\\client.h', 'CFLAGS_PDO_SNOWFLAKE', configure_module_dirname + '\\libsnowflakeclient\\include')) {


### PR DESCRIPTION
Adds `iphlpapi.lib` to the Windows library list in `config.w32`.

Recent versions of the bundled `libcurl_a.lib` reference `if_nametoindex` (used for IPv6 scoped address handling), which on Windows lives in `iphlpapi.dll`. Without linking against `iphlpapi.lib`, the build fails with:

```powershell
libcurl_a.lib(url.obj) : error LNK2019: unresolved external symbol "__imp_if_nametoindex" referenced in function "zonefrom_url".
C:\php-sdk\phpmaster\vs17\x64\php-src\x64\Release_TS\php_pdo_snowflake.dll : fatal error LNK1120: 1 unresolved externals
NMAKE : fatal error U1077: ""link.exe" @"C:\php-sdk\phpmaster\vs17\x64\php-src\x64\Release_TS\resp\PDO_SNOWFLAKE_GLOBAL_OBJS.txt" 
```

`iphlpapi.lib` is a standard Windows SDK library and is always available in VS16/VS17 build environments.

Command that triggered this error:

```powershell
.\scripts\run_build_pdo_snowflake.bat x64 Release VS17 8.4.17 C:\php-sdk
```
