### PR TITLE
Fix path in powershell command in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -189,7 +189,7 @@ To build the PHP driver for Windows:
 
    .. code-block:: batch
 
-       C:\php\php.exe -dextension=ext\php_pdo_snowflake.dll -m
+       C:\php\php.exe -dextension=".\ext\php_pdo_snowflake.dll" -m
 
    :code:`pdo_snowflake` should appear in the output from the command.
 


### PR DESCRIPTION
Running the original command resulted in an error:

```powershell
PS C:\xampp\php> php.exe -dextension=ext\php_pdo_snowflake.dll -m
Could not open input file: .dll
```

Running the new command correctly retunrs the list of loaded modules:

```powershell
PS C:\xampp\php> php.exe -dextension=".\ext\php_pdo_snowflake.dll" -m
[PHP Modules]
# ...
pdo_snowflake
# ...
```