### PR TITLE
ci: fail CI when run-tests.php reports test failures

### DIFF
--- a/.github/workflows/scripts/check_result.py
+++ b/.github/workflows/scripts/check_result.py
@@ -5,18 +5,16 @@ import fileinput
 
 
 def read_test_dir(outputdir):
-    allfiles= []
+    if not os.path.isdir(outputdir):
+        print("[ERROR] test output directory not found: " + outputdir)
+        sys.exit(1)
     resultfiles = []
-    try:
-        for (dirpath, dirnames, filenames) in os.walk(outputdir):
-            allfiles.extend(filenames)
-        for file in allfiles:
-            filename, file_extension = os.path.splitext(file)
-            if file_extension == '.out' or file_extension == '.log':
+    for (dirpath, dirnames, filenames) in os.walk(outputdir):
+        for file in filenames:
+            _, file_extension = os.path.splitext(file)
+            if file_extension in ('.out', '.log', '.diff'):
                 resultfiles.append(file)
-        return resultfiles
-    except:
-        return resultfiles
+    return resultfiles
 
 
 def main(argv):

--- a/.github/workflows/scripts/test_driver.py
+++ b/.github/workflows/scripts/test_driver.py
@@ -1,5 +1,6 @@
 # This script is to build the snowflake driver in github action
 import os
+import re
 import sys
 import subprocess
 
@@ -23,6 +24,27 @@ def run_command_no_exit(cmd):
         print(line.strip().decode('utf-8'))
     for line in result.stderr:
         print(line.strip().decode('utf-8'))
+
+
+def run_command_capture(cmd):
+    print(cmd)
+    result = subprocess.Popen(cmd, stderr=subprocess.STDOUT, stdout=subprocess.PIPE, shell=True)
+    lines = []
+    for line in result.stdout:
+        decoded = line.rstrip().decode('utf-8', 'replace')
+        print(decoded)
+        lines.append(decoded)
+    result.wait()
+    return result.returncode, "\n".join(lines)
+
+
+def assert_no_test_failures(test_output):
+    match = re.search(r'Tests failed\s*:\s*(\d+)', test_output)
+    failed = int(match.group(1)) if match else 0
+    has_failed_summary = re.search(r'(?m)^=*\s*FAILED TEST SUMMARY', test_output) is not None
+    if failed > 0 or has_failed_summary:
+        print("[ERROR] run-tests.php reported %d failing test(s)" % failed)
+        exit(1)
 
 
 def test_windows():
@@ -49,9 +71,10 @@ def test_windows():
 
     print ("====> run test")
     run_tests_file = os.path.join("D:\\php-sdk\\phpmaster", vs, arch, "php-src", "run-tests.php")
-    run_command_no_exit("php.exe " + run_tests_file + " .\\tests -d extension=pdo_snowflake || ver>null")
+    rc, test_output = run_command_capture("php.exe " + run_tests_file + " .\\tests -d extension=pdo_snowflake || ver>null")
     print ("====> parse test results")
     run_command("python .\\.github\\workflows\\scripts\\check_result.py .\\tests")
+    assert_no_test_failures(test_output)
 
 
 
@@ -75,9 +98,10 @@ def test_posix():
     run_test_options = ""
     if use_valgrind == 'true' or use_valgrind == '1':
         run_test_options = run_test_options + ' -m'
-    run_command_no_exit("php -d 'open_basedir=' -d 'output_buffering=0' -d 'memory_limit=-1' ./run-tests.php -d extension=modules/pdo_snowflake.so" + run_test_options)
+    rc, test_output = run_command_capture("php -d 'open_basedir=' -d 'output_buffering=0' -d 'memory_limit=-1' ./run-tests.php -d extension=modules/pdo_snowflake.so" + run_test_options)
     print ("====> parse test results")
     run_command("python ./.github/workflows/scripts/check_result.py ./tests")
+    assert_no_test_failures(test_output)
 
     coverage = os.environ.get('REPORT_COVERAGE', 'undef')
     if coverage == 'true' or coverage == '1':


### PR DESCRIPTION
The test step ran run-tests.php via run_command_no_exit (ignoring its result) and relied solely on check_result.py scanning for leftover .out/.log files. In some environments (e.g. the Rocky Linux 9 container) failing tests leave no such files, so check_result.py reported "all tests pass" and the job went green despite run-tests.php printing "Tests failed : 38" / "FAILED TEST SUMMARY".

- test_driver.py: capture run-tests.php output and fail the job on its own authoritative summary (non-zero "Tests failed" / "FAILED TEST SUMMARY"), for both posix and windows. check_result.py is kept as a secondary signal.
- check_result.py: drop the bare except that silently returned "pass", error out if the output dir is missing, and also treat .diff files as failures.