### PR TITLE
Mask priv_key_file_pwd in DEBUG log output

### DIFF
--- a/snowflake_driver.c
+++ b/snowflake_driver.c
@@ -818,7 +818,7 @@ pdo_snowflake_handle_factory(pdo_dbh_t *dbh, zval *driver_options) /* {{{ */
             vars[PDO_SNOWFLAKE_CONN_ATTR_PRIV_KEY_FILE_PWD_IDX].optval);
     }
     PDO_LOG_DBG(
-        "priv_key_file_pwd: %s", vars[PDO_SNOWFLAKE_CONN_ATTR_PRIV_KEY_FILE_PWD_IDX].optval);
+        "priv_key_file_pwd: %s", vars[PDO_SNOWFLAKE_CONN_ATTR_PRIV_KEY_FILE_PWD_IDX].optval != NULL ? "******" : "(NULL)");
 
     if (vars[PDO_SNOWFLAKE_CONN_ATTR_PROXY_IDX].optval != NULL) {
         /* proxy */


### PR DESCRIPTION
Fixes #515.

`pdo_snowflake_handle_factory` masks other secret connection parameters (`password`, `proxy`, `passcode`, `oauth_client_secret`) as `******` in DEBUG log output, but logged the private-key passphrase verbatim. With `pdo_snowflake.loglevel=DEBUG` (or `SNOWFLAKE_LOG_LEVEL=DEBUG`) the passphrase protecting the key-pair-auth private key was written to the driver log file.

This applies the same masking pattern already used for `proxy` two blocks below.