### PR TITLE
Mask priv_key_file_pwd in DEBUG log output

### DIFF
--- a/snowflake_driver.c
+++ b/snowflake_driver.c
@@ -818,7 +818,7 @@ pdo_snowflake_handle_factory(pdo_dbh_t *dbh, zval *driver_options) /* {{{ */
             vars[PDO_SNOWFLAKE_CONN_ATTR_PRIV_KEY_FILE_PWD_IDX].optval);
     }
     PDO_LOG_DBG(
-        "priv_key_file_pwd: %s", vars[PDO_SNOWFLAKE_CONN_ATTR_PRIV_KEY_FILE_PWD_IDX].optval);
+        "priv_key_file_pwd: %s", vars[PDO_SNOWFLAKE_CONN_ATTR_PRIV_KEY_FILE_PWD_IDX].optval != NULL ? "******" : "(NULL)");
 
     if (vars[PDO_SNOWFLAKE_CONN_ATTR_PROXY_IDX].optval != NULL) {
         /* proxy */


### PR DESCRIPTION
Recreates #516 on an internal branch so CI can run with repo secrets (the fork PR can't access `SNOWFLAKE_TEST_USER` etc.).
`pdo_snowflake_handle_factory` masked every other secret connection parameter (`password`, `proxy`, `passcode`, `oauth_client_secret`) as `******` in DEBUG log output, but logged the private-key passphrase verbatim. This applies the same masking pattern.
Authored by @pchemali — full credit to the original PR #516.
Closes #515