### PR TITLE
SNOW-3887909 bump GitHub Actions to Node 24-compatible majors

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -44,7 +44,7 @@ jobs:
 #      TEST_PHP_EXECUTABLE: c:\tools\php\php.exe
 #    # Steps represent a sequence of tasks that will be executed as part of the job
 #    steps:
-#      - uses: actions/checkout@v4
+#      - uses: actions/checkout@v7
 #      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
 #      - name: setup php
 #        uses: shivammathur/setup-php@v2
@@ -80,7 +80,7 @@ jobs:
       TEST_PHP_EXECUTABLE: c:\tools\php\php.exe
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: setup php
         uses: shivammathur/setup-php@v2
@@ -113,7 +113,7 @@ jobs:
       USE_VALGRIND: 0
     steps:
         # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v7
         - name: setup php
           uses: shivammathur/setup-php@v2
           with:
@@ -140,7 +140,7 @@ jobs:
       NO_INTERACTION: true
     steps:
         # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v7
         - name: setup php
           uses: shivammathur/setup-php@v2
           with:
@@ -170,7 +170,7 @@ jobs:
       NO_INTERACTION: true
       USE_VALGRIND: 0
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Build Driver and Run Tests in Docker
         run: ./scripts/test_rockylinux9_docker.sh
         shell: bash
@@ -186,7 +186,7 @@ jobs:
       USE_VALGRIND: 0
     steps:
         # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v7
         - name: setup php
           uses: shivammathur/setup-php@v2
           with:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -14,7 +14,7 @@ jobs:
     if: ${{!contains(github.event.pull_request.labels.*.name, 'NO-CHANGELOG-UPDATES')}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/wif_ssh_tests.yml
+++ b/.github/workflows/wif_ssh_tests.yml
@@ -31,7 +31,7 @@ jobs:
       WIF_SSH_KEY_GCP: ${{ secrets.WIF_SSH_KEY_GCP }}
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
## Summary
- Bump JavaScript GitHub Actions to Node 24-compatible majors to avoid Node.js 20 runner deprecation warnings.
- `actions/checkout@v3|v4` → `actions/checkout@v7` in `build_test.yml`, `changelog.yml`, and `wif_ssh_tests.yml`.

## Test plan
- [x] Confirm CI workflows start successfully on this PR
- [ ] Confirm no Node.js 20 deprecation warnings from upgraded `actions/checkout` steps